### PR TITLE
Use configuration to skip deployment

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -844,7 +844,9 @@
         <executions>
           <execution>
             <id>default-deploy</id>
-            <phase>none</phase>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This PR is to use configuration to avoid the deployment instead of specifying "none" phase.
The reason behind this is that product tools can handle the configuration and make it from true(=not deploy) to false( =do deploy). The product build env required deployment of every artifacts.

The PR will not chang the "skip" deployment behaviour but it can make sure it can be built in product env.