### PR TITLE
Zeroclipboard

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -763,29 +763,6 @@
     <outputDirectory>src/main/webapp/WEB-INF/classes</outputDirectory>
 
     <plugins>
-
-      <!-- See http://stackoverflow.com/questions/19905695/maven-how-to-include-annotation-generated-java-files-in-the-jar -->
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-annotations</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>target/generated-sources/annotations</directory>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
@@ -793,6 +770,7 @@
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
           <localWorkers>1</localWorkers>
           <extraJvmArgs>-Xmx2048m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+          <module>org.drools.workbench.FastCompiledDroolsWorkbench</module>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
@@ -919,10 +897,16 @@
         </configuration>
         <executions>
           <execution>
-            <configuration>
-              <module>org.drools.workbench.FastCompiledDroolsWorkbench</module>
-            </configuration>
+            <id>gwt-clean</id>
+            <phase>clean</phase>
             <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>gwt-compile</id>
+            <goals>
+              <goal>resources</goal>
               <goal>compile</goal>
             </goals>
           </execution>

--- a/drools-wb-webapp/src/main/webapp/drools-wb.html
+++ b/drools-wb-webapp/src/main/webapp/drools-wb.html
@@ -15,7 +15,6 @@
 
     <script src="org.drools.workbench.DroolsWorkbench/zeroclipboard/ZeroClipboard.min.js"></script>
     <script src="org.drools.workbench.DroolsWorkbench/zeroclipboard/ZeroClipboardLoader.js"></script>
-    <script src="org.drools.workbench.DroolsWorkbench/js/uri.min.js"></script>
 
     <!-- The GWT js file generated at run time -->
     <script type="text/javascript" src='org.drools.workbench.DroolsWorkbench/org.drools.workbench.DroolsWorkbench.nocache.js'></script>


### PR DESCRIPTION
Revert "fix" for my development environment -- wasn't such a "fix" after all :(

Remove script tag to inject uri.min.js as it is injected into the hostpage by org.uberfire:uberfire-api.