### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/drools-wb-webapp/src/main/resources/ErraiApp.properties
+++ b/drools-wb-webapp/src/main/resources/ErraiApp.properties
@@ -30,4 +30,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/drools-wb-webapp/src/main/webapp/WEB-INF/web.xml
@@ -59,6 +59,16 @@
     <url-pattern>/maven2/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/drools-wb.html</url-pattern>
+  </filter-mapping>
+
   <context-param>
     <param-name>resteasy.scan</param-name>
     <param-value>true</param-value>


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.