### PR TITLE
Bug 1251017 - Having added consecutive restrictions on fields with "j…

### DIFF
--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/ConstraintValueEditor.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/ConstraintValueEditor.java
@@ -358,8 +358,14 @@ public class ConstraintValueEditor
             dp.addValueChangeHandler( new ValueChangeHandler<Date>() {
 
                 public void onValueChange( final ValueChangeEvent<Date> event ) {
-                    constraint.setValue( PopupDatePicker.convertToString( event ) );
-                    executeOnValueChangeCommand();
+                    String value = PopupDatePicker.convertToString( event );
+                    boolean update = constraint.getValue() == null || !constraint.getValue().equals( value );
+
+                    constraint.setValue( value );
+
+                    if ( update ) {
+                        executeOnValueChangeCommand();
+                    }
                 }
 
             } );


### PR DESCRIPTION
…ava.util.Date" type in Guided Rule causes the browser to hang when choosing "Literal value"