### PR TITLE
GUVNOR-2269: Work Item Definition editor does not open following migration to BS3-PF

### DIFF
--- a/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/main/java/org/drools/workbench/screens/workitems/client/editor/WorkItemsEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-workitems-editor/drools-wb-workitems-editor-client/src/main/java/org/drools/workbench/screens/workitems/client/editor/WorkItemsEditorViewImpl.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.workitems.client.editor;
 
 import java.util.List;
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
@@ -66,6 +67,10 @@ public class WorkItemsEditorViewImpl
     public WorkItemsEditorViewImpl( final WorkItemDefinitionElementsBrowser workItemBrowser ) {
         this.workItemBrowser = checkNotNull( "workItemBrowser", workItemBrowser );
         this.workItemBrowser.init( this );
+    }
+
+    @PostConstruct
+    public void bind() {
         initWidget( uiBinder.createAndBindUi( this ) );
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2269