### PR TITLE
BZ 1257573 (6.1.z) Test Scenario: Imports added after the scenario has been ran are forgotten

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorViewImpl.java
@@ -75,6 +75,7 @@ public class ScenarioEditorViewImpl
     private OverviewWidgetPresenter  overviewWidget;
     private Callback<Scenario>       updateModelCallback;
     private VersionRecordManager     versionRecordManager;
+    private boolean isReadOnly = true;
 
     @Inject
     public ScenarioEditorViewImpl(
@@ -115,6 +116,7 @@ public class ScenarioEditorViewImpl
                            final Caller<ScenarioTestEditorService> service,
                            final Callback<Scenario> updateModelCallback) {
         this.updateModelCallback = updateModelCallback;
+        this.isReadOnly = isReadOnly;
         layout.clear();
         multiPage.clear();
 
@@ -343,6 +345,9 @@ public class ScenarioEditorViewImpl
                                                                             oracle,
                                                                             scenario,
                                                                             ruleNameService);
+
+        initImportsTab( oracle, scenario.getImports(), isReadOnly);
+
         scenarioWidgetComponentCreator.setShowResults(false);
     }
 


### PR DESCRIPTION
This fix is only for 6.2.x branch. 

Fix for 6.3.x and master is here. Due to differences in code I could not cherry-pick the previous fix.
https://github.com/droolsjbpm/drools-wb/commit/0aae1eb48cc18fdcb935ed120c315a257fcbb392
