### PR TITLE
GUVNOR-2268 : Test Scenarios: Switch to using uberfire-extensions DatePicker

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/pom.xml
@@ -133,6 +133,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDataConstraintEditor.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDataConstraintEditor.java
@@ -40,9 +40,7 @@ import org.drools.workbench.screens.guided.rule.client.widget.EnumDropDown;
 import org.drools.workbench.screens.testscenario.client.resources.i18n.TestScenarioConstants;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.widget.DatePickerTextBox;
 import org.uberfire.ext.widgets.common.client.common.DropDownValueChanged;
-import org.uberfire.ext.widgets.common.client.common.ValueChanged;
 
 /**
  * Constraint editor for the FieldData in the Given Section
@@ -183,15 +181,19 @@ public class FieldDataConstraintEditor
 
     }
 
-    private DatePickerTextBox dateEditor() {
-        DatePickerTextBox editor = new DatePickerTextBox( field.getValue() );
-        editor.setTitle( TestScenarioConstants.INSTANCE.ValueFor0( field.getName() ) );
-        editor.addValueChanged( new ValueChanged() {
-            public void valueChanged( String newValue ) {
-                field.setValue( newValue );
+    private Widget dateEditor() {
+
+        FieldDatePicker fieldDatePicker = new FieldDatePicker( new FieldDatePickerViewImpl() );
+
+        fieldDatePicker.setValue( field.getValue() );
+
+        fieldDatePicker.addValueChangeHandler( new ValueChangeHandler<String>() {
+            @Override
+            public void onValueChange( ValueChangeEvent<String> event ) {
+                field.setValue( event.getValue() );
             }
         } );
-        return editor;
+        return fieldDatePicker.asWidget();
     }
 
     private Widget variableEditor() {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePicker.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePicker.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.testscenario.client;
+
+import java.util.Date;
+
+import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+
+public class FieldDatePicker
+        implements IsWidget,
+                   HasValueChangeHandlers<String> {
+
+    private final DateTimeFormat formatter = getFormat();
+
+    private FieldDatePickerView view;
+
+    private HandlerManager handlerManager = new HandlerManager( this );
+
+    public FieldDatePicker( final FieldDatePickerView view ) {
+        this.view = view;
+        view.setPresenter( this );
+    }
+
+    public void setValue( String value ) {
+        if ( value != null && !value.trim().isEmpty() ) {
+            view.setValue( formatter.parse( value ) );
+        }
+    }
+
+    @Override
+    public Widget asWidget() {
+        return view.asWidget();
+    }
+
+    public HandlerRegistration addValueChangeHandler( final ValueChangeHandler<String> handler ) {
+
+        HandlerRegistration registration = new HandlerRegistration() {
+            @Override
+            public void removeHandler() {
+                handlerManager.removeHandler( ValueChangeEvent.getType(), handler );
+            }
+        };
+
+        handlerManager.addHandler( ValueChangeEvent.getType(), handler );
+
+        return registration;
+    }
+
+    public void onDateSelected( Date value ) {
+        ValueChangeEvent.fire( this, formatter.format( value ) );
+    }
+
+    @Override
+    public void fireEvent( GwtEvent<?> event ) {
+        handlerManager.fireEvent( event );
+    }
+
+    protected DateTimeFormat getFormat() {
+        return DateTimeFormat.getFormat( ApplicationPreferences.getDroolsDateFormat() );
+    }
+}

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerView.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.testscenario.client;
+
+import java.util.Date;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+public interface FieldDatePickerView
+        extends IsWidget {
+
+    void setValue( Date parse );
+
+    void setPresenter( FieldDatePicker presenter );
+
+}

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerViewImpl.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerViewImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.testscenario.client;
+
+import java.util.Date;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.user.client.ui.Widget;
+import org.uberfire.ext.widgets.common.client.common.DatePicker;
+
+public class FieldDatePickerViewImpl
+        implements FieldDatePickerView {
+
+    private DatePicker datePicker = new DatePicker();
+    private FieldDatePicker presenter;
+
+    public FieldDatePickerViewImpl() {
+        datePicker.addValueChangeHandler( new ValueChangeHandler<Date>() {
+            @Override
+            public void onValueChange( ValueChangeEvent<Date> event ) {
+                presenter.onDateSelected( event.getValue() );
+            }
+        } );
+    }
+
+    @Override
+    public void setValue( Date value ) {
+        datePicker.setValue( value );
+    }
+
+    @Override
+    public void setPresenter( FieldDatePicker presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public Widget asWidget() {
+        return datePicker;
+    }
+}

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFieldConstraintEditor.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/main/java/org/drools/workbench/screens/testscenario/client/VerifyFieldConstraintEditor.java
@@ -50,7 +50,6 @@ import org.gwtbootstrap3.client.ui.TextBox;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.kie.workbench.common.widgets.client.resources.CommonAltedImages;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
-import org.kie.workbench.common.widgets.client.widget.DatePickerTextBox;
 import org.kie.workbench.common.widgets.client.widget.TextBoxFactory;
 import org.uberfire.ext.widgets.common.client.common.DropDownValueChanged;
 import org.uberfire.ext.widgets.common.client.common.InfoPopup;
@@ -106,15 +105,17 @@ public class VerifyFieldConstraintEditor extends Composite {
                                          oracle.getResourcePath() ) );
 
         } else if ( flType != null && flType.equals( DataType.TYPE_DATE ) ) {
-            final DatePickerTextBox datePicker = new DatePickerTextBox( field.getExpected() );
-            String m = TestScenarioConstants.INSTANCE.ValueFor0( field.getFieldName() );
-            datePicker.setTitle( m );
-            datePicker.addValueChanged( new ValueChanged() {
-                public void valueChanged( String newValue ) {
-                    field.setExpected( newValue );
+            FieldDatePicker fieldDatePicker= new FieldDatePicker( new FieldDatePickerViewImpl() );
+            fieldDatePicker.setValue( field.getExpected() );
+
+            fieldDatePicker.addValueChangeHandler( new ValueChangeHandler<String>() {
+                @Override
+                public void onValueChange( ValueChangeEvent<String> event ) {
+                    field.setExpected( event.getValue() );
                 }
             } );
-            panel.add( datePicker );
+
+            panel.add( fieldDatePicker );
 
         } else {
             Map<String, String> currentValueMap = new HashMap<String, String>();

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/FieldDatePickerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.testscenario.client;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class FieldDatePickerTest {
+
+    @GwtMock
+    DateTimeFormat dateTimeFormat;
+
+    private FieldDatePickerView view;
+    private FieldDatePicker presenter;
+
+    private String selectedTime;
+    private Date date = new Date( 1 );
+    private Date otherDate = new Date( 2 );
+
+    @Before
+    public void setUp() throws Exception {
+        HashMap<String, String> preferences = new HashMap<String, String>();
+        preferences.put( ApplicationPreferences.DATE_FORMAT, "dd-MMM-yyyy" );
+        ApplicationPreferences.setUp( preferences );
+        view = mock( FieldDatePickerView.class );
+        presenter = new FieldDatePicker( view ) {
+            @Override protected DateTimeFormat getFormat() {
+                return dateTimeFormat;
+            }
+        };
+
+        when( dateTimeFormat.parse( "" ) ).thenThrow( new IllegalArgumentException() ); // The parser does not like empty strings
+        when( dateTimeFormat.format( date ) ).thenReturn( "some date" );
+        when( dateTimeFormat.format( otherDate ) ).thenReturn( "some other date" );
+
+        presenter.addValueChangeHandler( new ValueChangeHandler<String>() {
+            @Override
+            public void onValueChange( ValueChangeEvent<String> event ) {
+                selectedTime = event.getValue();
+            }
+        } );
+    }
+
+    @Test
+    public void testPresenterSet() throws Exception {
+        verify( view ).setPresenter( presenter );
+    }
+
+    @Test
+    public void testSetEmptyStringAsValue() throws Exception {
+        presenter.setValue( "" );
+
+    }
+
+    @Test
+    public void testSelectDate() throws Exception {
+
+        presenter.onDateSelected( date );
+
+        assertEquals( "some date", selectedTime );
+
+        presenter.onDateSelected( otherDate );
+
+        assertEquals( "some other date", selectedTime );
+    }
+
+}


### PR DESCRIPTION
Part uno. Can be merged in as it is. 
Part dos will remove the legacy date picker from kie-wb-commons and needs to be done after this. 

![datepicker](https://cloud.githubusercontent.com/assets/331092/10476687/cf936a9e-7258-11e5-8779-c3f3e663ea3c.png)
