### PR TITLE
Fixes search for rules that have the default package 

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -65,7 +65,10 @@ public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingT
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -88,7 +91,9 @@ public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingT
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) ).build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleAttributeNameTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -59,7 +59,9 @@ public class IndexRuleAttributeNameTest extends BaseIndexingTest<DRLResourceType
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.mockito.ArgumentMatcher;
@@ -71,7 +71,9 @@ public class IndexRuleInvalidDrlTest extends BaseIndexingTest<DRLResourceTypeDef
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -66,7 +66,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<DRLResourceType
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -91,7 +93,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<DRLResourceType
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -59,7 +59,9 @@ public class IndexRuleTest extends BaseIndexingTest<DRLResourceTypeDefinition> {
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "myRule" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "myRule" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-backend/src/test/java/org/drools/workbench/screens/drltext/backend/server/indexing/IndexRuleTypeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -63,7 +63,9 @@ public class IndexRuleTypeTest extends BaseIndexingTest<DRLResourceTypeDefinitio
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.drltext.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -80,7 +82,10 @@ public class IndexRuleTypeTest extends BaseIndexingTest<DRLResourceTypeDefinitio
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().useWildcards().addTerm( new ValueTypeIndexTerm( "*.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .useWildcards()
+                    .addTerm( new ValueTypeIndexTerm( "*.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslEntriesTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslEntriesTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
@@ -67,7 +67,10 @@ public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinit
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().useWildcards().addTerm( new ValueRuleIndexTerm( "*" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .useWildcards()
+                    .addTerm( new ValueRuleIndexTerm( "*" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -82,7 +85,9 @@ public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinit
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -106,7 +111,9 @@ public class IndexDslEntriesTest extends BaseIndexingTest<DSLResourceTypeDefinit
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/test/java/org/drools/workbench/screens/dsltext/backend/server/indexing/IndexDslInvalidDrlTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.mockito.ArgumentMatcher;
@@ -71,7 +71,9 @@ public class IndexDslInvalidDrlTest extends BaseIndexingTest<DSLResourceTypeDefi
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
 
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dsltext.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameAndValueCompositionTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -66,7 +66,10 @@ public class IndexDecisionTableXLSAttributeNameAndValueCompositionTest extends B
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -89,7 +92,10 @@ public class IndexDecisionTableXLSAttributeNameAndValueCompositionTest extends B
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSAttributeNameTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -65,7 +65,9 @@ public class IndexDecisionTableXLSAttributeNameTest extends BaseIndexingTest<Dec
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSInvalidDrlTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -72,7 +72,10 @@ public class IndexDecisionTableXLSInvalidDrlTest extends BaseIndexingTest<Decisi
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/indexing/IndexDecisionTableXLSMultipleTypesTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -65,7 +65,9 @@ public class IndexDecisionTableXLSMultipleTypesTest extends BaseIndexingTest<Dec
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dtablexls.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dtablexls.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -90,7 +92,9 @@ public class IndexDecisionTableXLSMultipleTypesTest extends BaseIndexingTest<Dec
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dtablexls.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.dtablexls.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/indexing/IndexEnumEntriesTest.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/test/java/org/drools/workbench/screens/enums/backend/server/indexing/IndexEnumEntriesTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFieldIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
@@ -72,7 +72,9 @@ public class IndexEnumEntriesTest extends BaseIndexingTest<EnumResourceTypeDefin
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -97,7 +99,9 @@ public class IndexEnumEntriesTest extends BaseIndexingTest<EnumResourceTypeDefin
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -120,7 +124,10 @@ public class IndexEnumEntriesTest extends BaseIndexingTest<EnumResourceTypeDefin
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Mortgage" ) ).addTerm( new ValueFieldIndexTerm( "amount" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.enums.backend.server.indexing.classes.Mortgage" ) )
+                    .addTerm( new ValueFieldIndexTerm( "amount" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -143,7 +150,9 @@ public class IndexEnumEntriesTest extends BaseIndexingTest<EnumResourceTypeDefin
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/util/indexing/IndexGlobalsInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/util/indexing/IndexGlobalsInvalidDrlTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.mockito.ArgumentMatcher;
@@ -70,7 +70,9 @@ public class IndexGlobalsInvalidDrlTest extends BaseIndexingTest<GlobalResourceT
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.util.ArrayList" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.util.ArrayList" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/util/indexing/IndexGlobalsTest.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/test/java/org/drools/workbench/screens/globals/backend/server/util/indexing/IndexGlobalsTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -66,7 +66,9 @@ public class IndexGlobalsTest extends BaseIndexingTest<GlobalResourceTypeDefinit
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.util.ArrayList" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.util.ArrayList" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableActionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -70,7 +70,9 @@ public class IndexGuidedDecisionTableActionsTest extends BaseIndexingTest<Guided
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableAttributesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableAttributesTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -71,7 +71,9 @@ public class IndexGuidedDecisionTableAttributesTest extends BaseIndexingTest<Gui
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -95,7 +97,10 @@ public class IndexGuidedDecisionTableAttributesTest extends BaseIndexingTest<Gui
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentActionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -71,7 +71,9 @@ public class IndexGuidedDecisionTableBRLFragmentActionsTest extends BaseIndexing
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -93,7 +95,9 @@ public class IndexGuidedDecisionTableBRLFragmentActionsTest extends BaseIndexing
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableBRLFragmentConditionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -71,7 +71,9 @@ public class IndexGuidedDecisionTableBRLFragmentConditionsTest extends BaseIndex
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -93,7 +95,9 @@ public class IndexGuidedDecisionTableBRLFragmentConditionsTest extends BaseIndex
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtable/backend/server/indexing/IndexGuidedDecisionTableConditionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -71,7 +71,9 @@ public class IndexGuidedDecisionTableConditionsTest extends BaseIndexingTest<Gui
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -93,7 +95,9 @@ public class IndexGuidedDecisionTableConditionsTest extends BaseIndexingTest<Gui
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtable.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.mockito.ArgumentMatcher;
@@ -71,7 +71,9 @@ public class IndexRuleInvalidDrlTest extends BaseIndexingTest<GuidedDTreeResourc
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "myRule" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "myRule" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -66,7 +66,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedDTreeReso
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -91,7 +93,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedDTreeReso
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -59,7 +59,9 @@ public class IndexRuleTest extends BaseIndexingTest<GuidedDTreeResourceTypeDefin
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "myRule" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "myRule" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/test/java/org/drools/workbench/screens/guided/dtree/backend/server/indexing/IndexRuleTypeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -63,7 +63,9 @@ public class IndexRuleTypeTest extends BaseIndexingTest<GuidedDTreeResourceTypeD
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.dtree.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -80,7 +82,10 @@ public class IndexRuleTypeTest extends BaseIndexingTest<GuidedDTreeResourceTypeD
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().useWildcards().addTerm( new ValueTypeIndexTerm( "*.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .useWildcards()
+                    .addTerm( new ValueTypeIndexTerm( "*.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameAndValueCompositionTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -65,7 +65,10 @@ public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingT
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -88,7 +91,10 @@ public class IndexRuleAttributeNameAndValueCompositionTest extends BaseIndexingT
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myAgendaGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleAttributeNameTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -59,7 +59,9 @@ public class IndexRuleAttributeNameTest extends BaseIndexingTest<GuidedRuleDRLRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleInvalidDrlTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleInvalidDrlTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.mockito.ArgumentMatcher;
@@ -71,7 +71,9 @@ public class IndexRuleInvalidDrlTest extends BaseIndexingTest<GuidedRuleDRLResou
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "myRule" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "myRule" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleMultipleTypesTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleMultipleTypesTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -66,7 +66,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedRuleDRLRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -91,7 +93,9 @@ public class IndexRuleMultipleTypesTest extends BaseIndexingTest<GuidedRuleDRLRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -59,7 +59,9 @@ public class IndexRuleTest extends BaseIndexingTest<GuidedRuleDRLResourceTypeDef
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "myRule" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "myRule" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTypeTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/indexing/IndexRuleTypeTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -63,7 +63,9 @@ public class IndexRuleTypeTest extends BaseIndexingTest<GuidedRuleDRLResourceTyp
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.rule.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -80,7 +82,10 @@ public class IndexRuleTypeTest extends BaseIndexingTest<GuidedRuleDRLResourceTyp
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().useWildcards().addTerm( new ValueTypeIndexTerm( "*.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .useWildcards()
+                    .addTerm( new ValueTypeIndexTerm( "*.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/indexing/IndexGuidedScoreCardTest.java
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/src/test/java/org/drools/workbench/screens/guided/scorecard/backend/server/indexing/IndexGuidedScoreCardTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFieldIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
@@ -89,7 +89,9 @@ public class IndexGuidedScoreCardTest extends BaseIndexingTest<GuidedScoreCardRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -114,7 +116,9 @@ public class IndexGuidedScoreCardTest extends BaseIndexingTest<GuidedScoreCardRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -137,7 +141,10 @@ public class IndexGuidedScoreCardTest extends BaseIndexingTest<GuidedScoreCardRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Mortgage" ) ).addTerm( new ValueFieldIndexTerm( "amount" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.scorecard.backend.server.indexing.classes.Mortgage" ) )
+                    .addTerm( new ValueFieldIndexTerm( "amount" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -160,7 +167,9 @@ public class IndexGuidedScoreCardTest extends BaseIndexingTest<GuidedScoreCardRe
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateActionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateActionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -71,7 +71,9 @@ public class IndexGuidedRuleTemplateActionsTest extends BaseIndexingTest<GuidedR
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -93,7 +95,9 @@ public class IndexGuidedRuleTemplateActionsTest extends BaseIndexingTest<GuidedR
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateAttributesTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateAttributesTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleAttributeValueIndexTerm;
@@ -72,7 +72,9 @@ public class IndexGuidedRuleTemplateAttributesTest extends BaseIndexingTest<Guid
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -96,7 +98,10 @@ public class IndexGuidedRuleTemplateAttributesTest extends BaseIndexingTest<Guid
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) ).addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleAttributeIndexTerm( "ruleflow-group" ) )
+                    .addTerm( new ValueRuleAttributeValueIndexTerm( "myRuleFlowGroup" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateConditionsTest.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/test/java/org/drools/workbench/screens/guided/template/server/indexing/IndexGuidedRuleTemplateConditionsTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueTypeIndexTerm;
 import org.uberfire.ext.metadata.backend.lucene.index.LuceneIndex;
@@ -71,7 +71,9 @@ public class IndexGuidedRuleTemplateConditionsTest extends BaseIndexingTest<Guid
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -93,7 +95,9 @@ public class IndexGuidedRuleTemplateConditionsTest extends BaseIndexingTest<Guid
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.guided.template.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/indexing/IndexTestScenarioTest.java
@@ -31,12 +31,11 @@ import org.drools.workbench.models.datamodel.imports.Import;
 import org.drools.workbench.models.testscenarios.backend.util.ScenarioXMLPersistence;
 import org.drools.workbench.models.testscenarios.shared.Scenario;
 import org.drools.workbench.screens.testscenario.type.TestScenarioResourceTypeDefinition;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.workbench.common.services.refactoring.backend.server.BaseIndexingTest;
 import org.kie.workbench.common.services.refactoring.backend.server.TestIndexer;
 import org.kie.workbench.common.services.refactoring.backend.server.indexing.RuleAttributeNameAnalyzer;
-import org.kie.workbench.common.services.refactoring.backend.server.query.QueryBuilder;
+import org.kie.workbench.common.services.refactoring.backend.server.query.builder.BasicQueryBuilder;
 import org.kie.workbench.common.services.refactoring.model.index.terms.RuleAttributeIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueFieldIndexTerm;
 import org.kie.workbench.common.services.refactoring.model.index.terms.valueterms.ValueRuleIndexTerm;
@@ -107,7 +106,9 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Applicant" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Applicant" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -132,7 +133,9 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Mortgage" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Mortgage" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -155,7 +158,10 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Mortgage" ) ).addTerm( new ValueFieldIndexTerm( "amount" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "org.drools.workbench.screens.testscenario.backend.server.indexing.classes.Mortgage" ) )
+                    .addTerm( new ValueFieldIndexTerm( "amount" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -178,7 +184,9 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.lang.Integer" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -203,7 +211,9 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueRuleIndexTerm( "test" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueRuleIndexTerm( "test" ) )
+                    .build();
 
             searcher.search( query,
                              collector );
@@ -225,7 +235,9 @@ public class IndexTestScenarioTest extends BaseIndexingTest<TestScenarioResource
             final IndexSearcher searcher = ( (LuceneIndex) index ).nrtSearcher();
             final TopScoreDocCollector collector = TopScoreDocCollector.create( 10,
                                                                                 true );
-            final Query query = new QueryBuilder().addTerm( new ValueTypeIndexTerm( "java.util.Date" ) ).build();
+            final Query query = new BasicQueryBuilder()
+                    .addTerm( new ValueTypeIndexTerm( "java.util.Date" ) )
+                    .build();
 
             searcher.search( query,
                              collector );


### PR DESCRIPTION
Bug 1257819 - GSS Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1
Bug 1257817 - Rules are not populated in dropdown list in Test Scenarios in BRMS 6.1

This fix needs the following PRs:
https://github.com/droolsjbpm/kie-wb-common/pull/116
https://github.com/droolsjbpm/drools-wb/pull/78
https://github.com/droolsjbpm/jbpm-designer/pull/67
https://github.com/droolsjbpm/jbpm-form-modeler/pull/17