### PR TITLE
Copy 'Full Text' search implementation from kie-wb-distributions.

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -142,6 +142,10 @@
       <artifactId>uberfire-widgets-commons</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.gwtbootstrap</groupId>
+      <artifactId>gwt-bootstrap</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/ComplementNavAreaView.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/ComplementNavAreaView.java
@@ -17,24 +17,34 @@
 package org.drools.workbench.client.navbar;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import com.github.gwtbootstrap.client.ui.Button;
+import com.github.gwtbootstrap.client.ui.TextBox;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Panel;
-import com.google.gwt.user.client.ui.RequiresResize;
+import org.kie.workbench.common.widgets.client.search.ClearSearchEvent;
+import org.kie.workbench.common.widgets.client.search.ContextualSearch;
+import org.kie.workbench.common.widgets.client.search.SearchBehavior;
+import org.kie.workbench.common.widgets.client.search.SetSearchTextEvent;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.widgets.menu.PerspectiveContextMenusPresenter;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
 /**
  * A stand-alone (i.e. devoid of Workbench dependencies) View
  */
 public class ComplementNavAreaView
         extends Composite
-        implements RequiresResize,
-                   ComplementNavAreaPresenter.View {
+        implements ComplementNavAreaPresenter.View {
 
     interface ViewBinder
             extends
@@ -45,7 +55,22 @@ public class ComplementNavAreaView
     private static ViewBinder uiBinder = GWT.create( ViewBinder.class );
 
     @UiField
+    public Button searchButton;
+
+    @UiField
+    public TextBox searchTextBox;
+
+    @Inject
+    private ContextualSearch contextualSearch;
+
+    @Inject
+    private PlaceManager placeManager;
+
+    @UiField
     public FlowPanel contextMenuArea;
+
+    @UiField
+    public FlowPanel searchPanel;
 
     @Inject
     private PerspectiveContextMenusPresenter contextMenu;
@@ -53,11 +78,29 @@ public class ComplementNavAreaView
     @PostConstruct
     public void init() {
         initWidget( uiBinder.createAndBindUi( this ) );
+        if ( Window.Location.getParameterMap().containsKey( "no_search" ) ) {
+            searchPanel.setVisible( false );
+        }
         contextMenuArea.add( contextMenu.getView() );
+        contextualSearch.setDefaultSearchBehavior( new SearchBehavior() {
+            @Override
+            public void execute( final String term ) {
+                placeManager.goTo( new DefaultPlaceRequest( "FullTextSearchForm" ).addParameter( "term", term ) );
+            }
+        } );
     }
 
-    @Override
-    public void onResize() {
+    @UiHandler("searchButton")
+    public void search( ClickEvent e ) {
+        contextualSearch.getSearchBehavior().execute( searchTextBox.getText() );
+    }
+
+    public void onClearSearchBox( @Observes ClearSearchEvent clearSearch ) {
+        searchTextBox.setText( "" );
+    }
+
+    public void onSetSearchText( @Observes SetSearchTextEvent setSearchText ) {
+        searchTextBox.setText( setSearchText.getSearchText() );
     }
 
 }

--- a/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/ComplementNavAreaView.ui.xml
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/ComplementNavAreaView.ui.xml
@@ -20,15 +20,12 @@
              xmlns:b="urn:import:com.github.gwtbootstrap.client.ui">
 
   <ui:with field="res" type="org.uberfire.client.resources.WorkbenchResources"/>
+  <ui:with field="i18n" type="org.drools.workbench.client.resources.i18n.AppConstants"/>
 
   <ui:style>
+
     .contextArea {
       height: 47px !important;
-    }
-
-    .logo {
-      float: left;
-      margin-left: 20px;
     }
 
     .search {
@@ -43,20 +40,13 @@
       margin-top: 7px;
     }
 
-    .searchForm {
-      margin-bottom: 0px !important;
-    }
   </ui:style>
 
   <g:FlowPanel styleName="{style.contextArea} {res.CSS.listbar}">
-    <g:HTMLPanel styleName="{style.logo}">
-      <img src="images/logo.png"/>
-    </g:HTMLPanel>
     <g:FlowPanel ui:field="contextMenuArea" styleName="{style.contextMenu}"/>
-    <g:FlowPanel addStyleNames="{style.search}">
-      <b:Form type="SEARCH" addStyleNames="{style.searchForm}">
-        <b:TextBox searchQuery="true" placeholder="search..."/>
-      </b:Form>
+    <g:FlowPanel addStyleNames="{style.search} input-append" ui:field="searchPanel">
+      <b:TextBox alternateSize="XLARGE" ui:field="searchTextBox" placeholder="{i18n.Search}"/>
+      <b:Button icon="SEARCH" ui:field="searchButton"/>
     </g:FlowPanel>
   </g:FlowPanel>
 

--- a/drools-wb-webapp/src/main/java/org/drools/workbench/client/resources/i18n/AppConstants.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/client/resources/i18n/AppConstants.java
@@ -74,10 +74,19 @@ public interface AppConstants
     String Project();
 
     String Repository();
+
     String Home();
+
     String Perspectives();
+
     String Logout();
+
     String Find();
+
     String Upload();
+
     String Refresh();
+
+    String Search();
+
 }

--- a/drools-wb-webapp/src/main/resources/org/drools/workbench/client/resources/i18n/AppConstants.properties
+++ b/drools-wb-webapp/src/main/resources/org/drools/workbench/client/resources/i18n/AppConstants.properties
@@ -24,3 +24,4 @@ Logout=Logout
 Find=Find
 Upload=Upload
 Refresh=Refresh
+Search=Search...


### PR DESCRIPTION
Copy back ```kie-wb-distributions``` implementation of "Full Text Search" to support debugging issues with said feature in ```drools-wb```. This is only required on 6.3.x as master does not support a top-level widget bar following the BS3 migration.