### PR TITLE
BZ1274349: Asset Management: Branch selector partially hidden. Setup drools-wb-webapp to support Asset Management.

### DIFF
--- a/drools-wb-webapp/src/main/java/org/drools/workbench/backend/server/PicketLinkDefaultUsers.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/backend/server/PicketLinkDefaultUsers.java
@@ -3,7 +3,7 @@
  * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -65,12 +65,15 @@ public class PicketLinkDefaultUsers {
 
         final Role roleAdmin = new Role( "admin" );
         final Role roleAnalyst = new Role( "analyst" );
+        final Role roleKieMgmt = new Role( "kiemgmt" );
 
         identityManager.add( roleAdmin );
         identityManager.add( roleAnalyst );
+        identityManager.add( roleKieMgmt );
 
         relationshipManager.add( new Grant( admin, roleAnalyst ) );
         relationshipManager.add( new Grant( admin, roleAdmin ) );
+        relationshipManager.add( new Grant( admin, roleKieMgmt ) );
 
         relationshipManager.add( new Grant( director, roleAnalyst ) );
 

--- a/drools-wb-webapp/src/main/resources/workbench-policy.properties
+++ b/drools-wb-webapp/src/main/resources/workbench-policy.properties
@@ -1,0 +1,73 @@
+#
+# Copyright (C) 2012 JBoss Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# List of features
+
+feature.wb_project_authoring=Project authoring
+feature.wb_artifact_repository=Artifact repository
+feature.wb_administration=Administration
+feature.wb_contributors=Contributors
+feature.wb_asset_management=Asset Management
+feature.wb_admin_ou=Organizational units
+feature.wb_admin_repos=Repositories
+feature.wb_plugin_management=PlugIn Management
+feature.wb_search=Search
+
+feature.wb_authoring=Authoring
+feature.wb_everything=Full access
+feature.wb_management=Management
+
+# List of project operation 
+feature.wb_project_authoring_save=Project Save Button
+feature.wb_project_authoring_delete=Project Delete Button
+feature.wb_project_authoring_copy=Project Copy Button
+feature.wb_project_authoring_rename=Project Rename Button
+feature.wb_project_authoring_buildAndDeploy=Project BuildAndDeploy Button
+
+# assets management features
+feature.wb_configure_repository=Configure Repositories Process
+feature.wb_promote_assets=Promote Assets Process
+feature.wb_release_project=Release Process
+
+# data modeller features
+feature.wb_data_modeler_edit_sources=Edit Java Sources
+
+# Groups of features
+# (Features can be excluded by adding the prefix  '!')
+# Groups of project operation
+profile.wb_project_operation=wb_project_authoring_save, wb_project_authoring_delete, wb_project_authoring_copy, wb_project_authoring_rename, wb_project_authoring_buildAndDeploy
+profile.wb_authoring=wb_project_authoring, wb_contributors, wb_asset_management, wb_artifact_repository, wb_administration, wb_admin_ou, wb_admin_repos
+profile.wb_plugins=wb_plugin_management
+profile.extensions=wb_extensions
+profile.perspective_editor = wb_perspective_editor
+profile.apps = wb_apps
+profile.datasets = wb_datasets
+
+profile.wb_everything=wb_authoring, wb_search, wb_management, wb_project_operation, wb_plugins, wb_extensions, wb_perspective_editor, wb_apps, wb_datasets, wb_data_modeler_edit_sources
+profile.wb_for_business_analysts=wb_everything, !wb_artifact_repository, !wb_administration, !wb_management, !wb_extensions, !wb_data_modeler_edit_sources
+profile.wb_for_assets_management=wb_configure_repository, wb_promote_assets, wb_release_project
+
+# Granted roles per feature
+# Users with a given role will only be able to access those features specified.
+#
+# NOTES:
+# - If a group feature is granted that also implies granting all its children features.
+# - Features left out of the list are granted to all roles by default.
+# - A role can be denied by adding the prefix  '!'.
+
+roles.wb_everything=admin
+roles.wb_for_business_analysts=analyst
+roles.wb_for_assets_management=kiemgmt


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1274349

This adds support for Asset Management to drools-wb-webapp; to support local development without needing to run kie-wb. There's no tests, there's no documentation. None of which is needed for drools-wb-webapp. 