### PR TITLE
UF-244: (Work-around) Default DEV environment to Wildfly 10.0.0(CR4)

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -882,7 +882,7 @@
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
           <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
-          <extraJvmArgs>-Xmx2048m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.marshalling.server.classOutput=${project.build.outputDirectory}</extraJvmArgs>
+          <extraJvmArgs>-Xmx2048m -XX:MaxPermSize=256m -Xms1024m -XX:PermSize=128m -Xss1M -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.marshalling.server.classOutput=${project.build.outputDirectory} -Dorg.uberfire.async.executor.safemode=true</extraJvmArgs>
           <module>org.drools.workbench.DroolsWorkbench</module>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-244

This PR provides a workaround to the issue (of ```Async``` EJBs not running on Wildfly 8.1 - which is our Hosted Mode environment). Support for System Property ```org.uberfire.async.executor.safemode``` to force use of ```Executors.newCachedThreadPool``` has been added.

This PR sets the said System Property to "true" to ensure Hosted Mode (which uses Wildfly 8.1) works without further ado with ```mvn gwt:run``` or from your favourite IDE.