### PR TITLE
GUVNOR-2327: Ace Editor layout doesn't respect asset editor bounds

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.java
@@ -22,16 +22,16 @@ import javax.annotation.PostConstruct;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.datamodel.rule.DSLSentence;
 import org.drools.workbench.screens.drltext.client.resources.i18n.DRLTextEditorConstants;
 import org.drools.workbench.screens.drltext.client.widget.ClickEvent;
 import org.drools.workbench.screens.drltext.client.widget.DSLSentenceBrowserWidget;
 import org.drools.workbench.screens.drltext.client.widget.FactTypeBrowserWidget;
-import org.gwtbootstrap3.client.ui.Column;
-import org.gwtbootstrap3.client.ui.Row;
-import org.kie.workbench.common.widgets.client.source.DrlEditor;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorViewImpl;
+import org.uberfire.ext.widgets.common.client.ace.AceEditor;
+import org.uberfire.ext.widgets.common.client.ace.AceEditorTheme;
 
 public class DRLEditorViewImpl
         extends KieEditorViewImpl
@@ -46,25 +46,23 @@ public class DRLEditorViewImpl
     private static ViewBinder uiBinder = GWT.create( ViewBinder.class );
 
     //Scroll-bar Height + Container padding * 2
-    private static int SCROLL_BAR_SIZE = 32;
+    private static int SCROLL_BAR_HEIGHT = 32;
     private static int CONTAINER_PADDING = 15;
-    private static int VERTICAL_MARGIN = SCROLL_BAR_SIZE + ( CONTAINER_PADDING * 2 );
+    private static int TAB_PANEL_HEIGHT = 34 + CONTAINER_PADDING;
+    private static int VERTICAL_MARGIN = SCROLL_BAR_HEIGHT + ( CONTAINER_PADDING * 2 ) + TAB_PANEL_HEIGHT;
 
     private FactTypeBrowserWidget factTypeBrowser = null;
     private DSLSentenceBrowserWidget dslConditionsBrowser = null;
     private DSLSentenceBrowserWidget dslActionsBrowser = null;
 
     @UiField
-    Row row;
+    HTMLPanel container;
 
     @UiField
-    Column columnBrowsers;
+    HTMLPanel browsers;
 
     @UiField
-    DrlEditor drlEditor;
-
-    @UiField
-    Column drlContainer;
+    AceEditor drlEditor;
 
     @Override
     public void init( final DRLEditorPresenter presenter ) {
@@ -89,9 +87,13 @@ public class DRLEditorViewImpl
                                                                DRLTextEditorConstants.INSTANCE.dslActions() );
         initWidget( uiBinder.createAndBindUi( this ) );
 
-        columnBrowsers.add( factTypeBrowser );
-        columnBrowsers.add( dslConditionsBrowser );
-        columnBrowsers.add( dslActionsBrowser );
+        drlEditor.startEditor();
+        drlEditor.setModeByName( "drools" );
+        drlEditor.setTheme( AceEditorTheme.CHROME );
+
+        browsers.add( factTypeBrowser );
+        browsers.add( dslConditionsBrowser );
+        browsers.add( dslActionsBrowser );
     }
 
     @Override
@@ -131,8 +133,8 @@ public class DRLEditorViewImpl
     @Override
     public void onResize() {
         final int height = getParent().getOffsetHeight() - VERTICAL_MARGIN;
-        row.setHeight( ( height > 0 ? height : 0 ) + "px" );
-        drlContainer.setHeight( ( ( height > 0 ? height : 0 ) + SCROLL_BAR_SIZE ) + "px" );
+        container.setHeight( ( height > 0 ? height : 0 ) + "px" );
+        drlEditor.setHeight( ( height > 0 ? height : 0 ) + "px" );
         drlEditor.onResize();
     }
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.ui.xml
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.ui.xml
@@ -16,17 +16,14 @@
 
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-             xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-             xmlns:drleditor="urn:import:org.kie.workbench.common.widgets.client.source">
+             xmlns:gwt="urn:import:com.google.gwt.user.client.ui"
+             xmlns:drleditor="urn:import:org.uberfire.ext.widgets.common.client.ace">
 
   <ui:with field="res" type="org.drools.workbench.screens.drltext.client.resources.DRLTextEditorResources"/>
 
-  <b:Container fluid="true">
-    <b:Row addStyleNames="{res.CSS.columnsContainer}" ui:field="row">
-      <b:Column size="MD_2" addStyleNames="{res.CSS.columnBrowsers}" ui:field="columnBrowsers"/>
-      <b:Column size="MD_10" addStyleNames="{res.CSS.drlEditorContainer}" ui:field="drlContainer">
-        <drleditor:DrlEditor ui:field="drlEditor"/>
-      </b:Column>
-    </b:Row>
-  </b:Container>
+  <gwt:HTMLPanel ui:field="container" styleName="{res.CSS.container}">
+    <gwt:HTMLPanel ui:field="browsers" styleName="{res.CSS.browsers}"/>
+    <drleditor:AceEditor ui:field="drlEditor"/>
+  </gwt:HTMLPanel>
+
 </ui:UiBinder>

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/resources/css/StylesCss.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/resources/css/StylesCss.java
@@ -29,10 +29,8 @@ public interface StylesCss
     @ClassName("category-explorer-Tree")
     String categoryExplorerTree();
 
-    String columnsContainer();
+    String container();
 
-    String columnBrowsers();
-
-    String drlEditorContainer();
+    String browsers();
 
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/resources/org/drools/workbench/screens/drltext/client/resources/css/Styles.css
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/resources/org/drools/workbench/screens/drltext/client/resources/css/Styles.css
@@ -21,25 +21,19 @@
     vertical-align: middle;
 }
 
-.columnsContainer {
+.container {
     margin: 14px 14px;
 }
 
-.columnBrowsers {
+.browsers {
     height: 100%;
     width: 280px;
-    overflow: auto;
+    overflow: scroll;
     background-color: #e6f1f6;
     border-top-left-radius: 5px;
     border-bottom-left-radius: 5px;
     border: solid 1px #ebebeb;
     padding: 15px;
-}
-
-.drlEditorContainer {
-    position: absolute;
-    bottom: 0;
-    top: 0;
-    left: 330px;
-    right: 0;
+    margin-right: 10px;
+    float: left;
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2327

View implementation changes only... hence no tests.

The "rinky dink" size constants are really a manifestation of issues with the BS3 TabPanel.. widgets getting their parent size would expect this to exclude the TabPanel header; however it appears it includes the header height and hence when setting the height of "child" Widgets we need to take the TabPanel header height into account :(