### PR TITLE
GUVNOR-2328: Asset Editor height doesn't count with the added top tabs

### DIFF
--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.java
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/java/org/drools/workbench/screens/drltext/client/editor/DRLEditorViewImpl.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -45,11 +46,7 @@ public class DRLEditorViewImpl
 
     private static ViewBinder uiBinder = GWT.create( ViewBinder.class );
 
-    //Scroll-bar Height + Container padding * 2
-    private static int SCROLL_BAR_HEIGHT = 32;
     private static int CONTAINER_PADDING = 15;
-    private static int TAB_PANEL_HEIGHT = 34 + CONTAINER_PADDING;
-    private static int VERTICAL_MARGIN = SCROLL_BAR_HEIGHT + ( CONTAINER_PADDING * 2 ) + TAB_PANEL_HEIGHT;
 
     private FactTypeBrowserWidget factTypeBrowser = null;
     private DSLSentenceBrowserWidget dslConditionsBrowser = null;
@@ -67,6 +64,17 @@ public class DRLEditorViewImpl
     @Override
     public void init( final DRLEditorPresenter presenter ) {
         this.factTypeBrowser.init( presenter );
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+        Scheduler.get().scheduleDeferred( new Scheduler.ScheduledCommand() {
+            @Override
+            public void execute() {
+                onResize();
+            }
+        } );
     }
 
     @PostConstruct
@@ -132,9 +140,10 @@ public class DRLEditorViewImpl
 
     @Override
     public void onResize() {
-        final int height = getParent().getOffsetHeight() - VERTICAL_MARGIN;
+        final int height = getParent().getOffsetHeight();
+        final int drlEditorHeight = height - CONTAINER_PADDING * 2;
         container.setHeight( ( height > 0 ? height : 0 ) + "px" );
-        drlEditor.setHeight( ( height > 0 ? height : 0 ) + "px" );
+        drlEditor.setHeight( ( drlEditorHeight > 0 ? drlEditorHeight : 0 ) + "px" );
         drlEditor.onResize();
     }
 }

--- a/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/resources/org/drools/workbench/screens/drltext/client/resources/css/Styles.css
+++ b/drools-wb-screens/drools-wb-drl-text-editor/drools-wb-drl-text-editor-client/src/main/resources/org/drools/workbench/screens/drltext/client/resources/css/Styles.css
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.category-explorer-Tree {
+.category-explorer-Tree {scroll-snap-coordinate: s
+;
     width: 100%;
 }
 
@@ -22,7 +23,7 @@
 }
 
 .container {
-    margin: 14px 14px;
+    padding: 15px;
 }
 
 .browsers {


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2328

Related PR: https://github.com/uberfire/uberfire/pull/266

This PR for ```drools-wb``` corrects the workaround for sizing added for https://issues.jboss.org/browse/GUVNOR-2327