### PR TITLE
GUVNOR-2273 : Replace "package name white list" with DependencyFilter and related UI improvements

### DIFF
--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-services-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
       <artifactId>guvnor-services-api</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/pom.xml
@@ -28,6 +28,10 @@
     </dependency>
     <dependency>
       <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-services-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
       <artifactId>guvnor-project-api</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorCopyHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorCopyHelper.java
@@ -23,6 +23,7 @@ import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.type.GuidedDTableResourceTypeDefinition;
 import org.drools.workbench.screens.guided.rule.backend.server.GuidedRuleEditorServiceUtilities;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.backend.service.helper.CopyHelper;
@@ -39,15 +40,19 @@ public class GuidedDecisionTableEditorCopyHelper implements CopyHelper {
     private GuidedDTableResourceTypeDefinition resourceType;
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
     private GuidedRuleEditorServiceUtilities utilities;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
+
     @Override
     public boolean supports( final Path destination ) {
-        return ( resourceType.accept( destination ) );
+        return (resourceType.accept( destination ));
     }
 
     @Override
@@ -66,7 +71,7 @@ public class GuidedDecisionTableEditorCopyHelper implements CopyHelper {
         //Save file
         ioService.write( _destination,
                          GuidedDTXMLPersistence.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtable/backend/server/GuidedDecisionTableEditorRenameHelper.java
@@ -23,6 +23,7 @@ import org.drools.workbench.models.guided.dtable.backend.GuidedDTXMLPersistence;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.type.GuidedDTableResourceTypeDefinition;
 import org.drools.workbench.screens.guided.rule.backend.server.GuidedRuleEditorServiceUtilities;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
@@ -40,7 +41,7 @@ public class GuidedDecisionTableEditorRenameHelper implements RenameHelper {
     private GuidedDTableResourceTypeDefinition resourceType;
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
@@ -49,9 +50,12 @@ public class GuidedDecisionTableEditorRenameHelper implements RenameHelper {
     @Inject
     private GuidedRuleEditorServiceUtilities utilities;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
     @Override
     public boolean supports( final Path destination ) {
-        return ( resourceType.accept( destination ) );
+        return (resourceType.accept( destination ));
     }
 
     @Override
@@ -70,7 +74,7 @@ public class GuidedDecisionTableEditorRenameHelper implements RenameHelper {
         //Save file
         ioService.write( _destination,
                          GuidedDTXMLPersistence.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorCopyHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorCopyHelper.java
@@ -24,6 +24,7 @@ import org.drools.workbench.models.datamodel.oracle.PackageDataModelOracle;
 import org.drools.workbench.models.guided.dtree.backend.GuidedDecisionTreeDRLPersistence;
 import org.drools.workbench.models.guided.dtree.shared.model.GuidedDecisionTree;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
@@ -56,6 +57,9 @@ public class GuidedDecisionTreeEditorCopyHelper implements CopyHelper {
     @Inject
     private DataModelService dataModelService;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
     @Override
     public boolean supports( final Path destination ) {
         return ( resourceType.accept( destination ) );
@@ -83,18 +87,7 @@ public class GuidedDecisionTreeEditorCopyHelper implements CopyHelper {
         //Save file
         ioService.write( _destination,
                          GuidedDecisionTreeDRLPersistence.getInstance().marshal( model ),
-                         makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
-    }
-
-    private CommentedOption makeCommentedOption( final String commitMessage ) {
-        final String name = identity.getIdentifier();
-        final Date when = new Date();
-        final CommentedOption co = new CommentedOption( sessionInfo.getId(),
-                                                        name,
-                                                        null,
-                                                        commitMessage,
-                                                        when );
-        return co;
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorRenameHelper.java
@@ -15,7 +15,6 @@
 */
 package org.drools.workbench.screens.guided.dtree.backend.server;
 
-import java.util.Date;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -24,13 +23,13 @@ import org.drools.workbench.models.datamodel.oracle.PackageDataModelOracle;
 import org.drools.workbench.models.guided.dtree.backend.GuidedDecisionTreeDRLPersistence;
 import org.drools.workbench.models.guided.dtree.shared.model.GuidedDecisionTree;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.backend.service.helper.RenameHelper;
 import org.uberfire.io.IOService;
-import org.uberfire.java.nio.base.options.CommentedOption;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.type.FileNameUtil;
 
@@ -55,6 +54,9 @@ public class GuidedDecisionTreeEditorRenameHelper implements RenameHelper {
 
     @Inject
     private DataModelService dataModelService;
+
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
 
     @Override
     public boolean supports( final Path destination ) {
@@ -83,18 +85,7 @@ public class GuidedDecisionTreeEditorRenameHelper implements RenameHelper {
         //Save file
         ioService.write( _destination,
                          GuidedDecisionTreeDRLPersistence.getInstance().marshal( model ),
-                         makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
-    }
-
-    private CommentedOption makeCommentedOption( final String commitMessage ) {
-        final String name = identity.getIdentifier();
-        final Date when = new Date();
-        final CommentedOption co = new CommentedOption( sessionInfo.getId(),
-                                                        name,
-                                                        null,
-                                                        commitMessage,
-                                                        when );
-        return co;
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtree-editor/drools-wb-guided-dtree-editor-backend/src/main/java/org/drools/workbench/screens/guided/dtree/backend/server/GuidedDecisionTreeEditorServiceImpl.java
@@ -32,8 +32,10 @@ import org.drools.workbench.models.guided.dtree.shared.model.GuidedDecisionTree;
 import org.drools.workbench.screens.guided.dtree.model.GuidedDecisionTreeEditorContent;
 import org.drools.workbench.screens.guided.dtree.service.GuidedDecisionTreeEditorService;
 import org.drools.workbench.screens.guided.dtree.type.GuidedDTreeResourceTypeDefinition;
+import org.guvnor.common.services.backend.config.SafeSessionInfo;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.file.JavaFileFilter;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.backend.validation.GenericValidator;
 import org.guvnor.common.services.project.model.Package;
 import org.guvnor.common.services.shared.metadata.MetadataService;
@@ -60,6 +62,7 @@ import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
+import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.ResourceOpenedEvent;
 import org.uberfire.workbench.type.FileNameUtil;
 
@@ -70,16 +73,16 @@ public class GuidedDecisionTreeEditorServiceImpl
         implements GuidedDecisionTreeEditorService {
 
     //Filters to include *all* applicable resources
-    private static final JavaFileFilter FILTER_JAVA = new JavaFileFilter();
-    private static final DRLFileFilter FILTER_DRL = new DRLFileFilter();
-    private static final DSLRFileFilter FILTER_DSLR = new DSLRFileFilter();
-    private static final DSLFileFilter FILTER_DSL = new DSLFileFilter();
-    private static final RDRLFileFilter FILTER_RDRL = new RDRLFileFilter();
-    private static final RDSLRFileFilter FILTER_RDSLR = new RDSLRFileFilter();
+    private static final JavaFileFilter    FILTER_JAVA   = new JavaFileFilter();
+    private static final DRLFileFilter     FILTER_DRL    = new DRLFileFilter();
+    private static final DSLRFileFilter    FILTER_DSLR   = new DSLRFileFilter();
+    private static final DSLFileFilter     FILTER_DSL    = new DSLFileFilter();
+    private static final RDRLFileFilter    FILTER_RDRL   = new RDRLFileFilter();
+    private static final RDSLRFileFilter   FILTER_RDSLR  = new RDSLRFileFilter();
     private static final GlobalsFileFilter FILTER_GLOBAL = new GlobalsFileFilter();
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
@@ -103,6 +106,20 @@ public class GuidedDecisionTreeEditorServiceImpl
     @Inject
     private GenericValidator genericValidator;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
+    private SafeSessionInfo safeSessionInfo;
+
+    public GuidedDecisionTreeEditorServiceImpl() {
+
+    }
+
+    @Inject
+    public GuidedDecisionTreeEditorServiceImpl( final SessionInfo sessionInfo ) {
+        safeSessionInfo = new SafeSessionInfo( sessionInfo );
+    }
+
     @Override
     public Path create( final Path context,
                         final String fileName,
@@ -110,7 +127,7 @@ public class GuidedDecisionTreeEditorServiceImpl
                         final String comment ) {
         try {
             final Package pkg = projectService.resolvePackage( context );
-            final String packageName = ( pkg == null ? null : pkg.getPackageName() );
+            final String packageName = (pkg == null ? null : pkg.getPackageName());
             content.setPackageName( packageName );
 
             final org.uberfire.java.nio.file.Path nioPath = Paths.convert( context ).resolve( fileName );
@@ -122,7 +139,7 @@ public class GuidedDecisionTreeEditorServiceImpl
 
             ioService.write( nioPath,
                              GuidedDecisionTreeDRLPersistence.getInstance().marshal( content ),
-                             makeCommentedOption( comment ) );
+                             commentedOptionFactory.makeCommentedOption( comment ) );
 
             return newPath;
 
@@ -151,33 +168,33 @@ public class GuidedDecisionTreeEditorServiceImpl
 
     @Override
     public GuidedDecisionTreeEditorContent loadContent( final Path path ) {
-        return super.loadContent(path);
+        return super.loadContent( path );
     }
 
     @Override
-    protected GuidedDecisionTreeEditorContent constructContent(Path path, Overview overview) {
-        final GuidedDecisionTree model = load(path);
-        final PackageDataModelOracle oracle = dataModelService.getDataModel(path);
+    protected GuidedDecisionTreeEditorContent constructContent( Path path, Overview overview ) {
+        final GuidedDecisionTree model = load( path );
+        final PackageDataModelOracle oracle = dataModelService.getDataModel( path );
         final PackageDataModelOracleBaselinePayload dataModel = new PackageDataModelOracleBaselinePayload();
 
         //Get FQCN's used by model
-        final GuidedDecisionTreeModelVisitor visitor = new GuidedDecisionTreeModelVisitor(model);
+        final GuidedDecisionTreeModelVisitor visitor = new GuidedDecisionTreeModelVisitor( model );
         final Set<String> consumedFQCNs = visitor.getConsumedModelClasses();
 
         //Get FQCN's used by Globals
-        consumedFQCNs.addAll(oracle.getPackageGlobals().values());
+        consumedFQCNs.addAll( oracle.getPackageGlobals().values() );
 
-        DataModelOracleUtilities.populateDataModel(oracle,
-                                                   dataModel,
-                                                   consumedFQCNs);
+        DataModelOracleUtilities.populateDataModel( oracle,
+                                                    dataModel,
+                                                    consumedFQCNs );
 
         //Signal opening to interested parties
-        resourceOpenedEvent.fire(new ResourceOpenedEvent(path,
-                                                         sessionInfo));
+        resourceOpenedEvent.fire( new ResourceOpenedEvent( path,
+                                                           safeSessionInfo ) );
 
-        return new GuidedDecisionTreeEditorContent(model,
-                                                   overview,
-                                                   dataModel);
+        return new GuidedDecisionTreeEditorContent( model,
+                                                    overview,
+                                                    dataModel );
     }
 
     @Override
@@ -212,7 +229,7 @@ public class GuidedDecisionTreeEditorServiceImpl
                              GuidedDecisionTreeDRLPersistence.getInstance().marshal( model ),
                              metadataService.setUpAttributes( resource,
                                                               metadata ),
-                             makeCommentedOption( comment ) );
+                             commentedOptionFactory.makeCommentedOption( comment ) );
 
             fireMetadataSocialEvents( resource, currentMetadata, metadata );
             return resource;

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelper.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelper.java
@@ -24,6 +24,7 @@ import org.drools.workbench.models.commons.backend.rule.RuleModelDRLPersistenceI
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDSLRResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
@@ -44,7 +45,7 @@ public class GuidedRuleEditorCopyHelper implements CopyHelper {
     private GuidedRuleDSLRResourceTypeDefinition dslrResourceType;
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
@@ -53,9 +54,12 @@ public class GuidedRuleEditorCopyHelper implements CopyHelper {
     @Inject
     private GuidedRuleEditorServiceUtilities utilities;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
     @Override
     public boolean supports( final Path destination ) {
-        return ( drlResourceType.accept( destination ) || dslrResourceType.accept( destination ) );
+        return (drlResourceType.accept( destination ) || dslrResourceType.accept( destination ));
     }
 
     @Override
@@ -85,7 +89,7 @@ public class GuidedRuleEditorCopyHelper implements CopyHelper {
         //Save file
         ioService.write( _destination,
                          RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
@@ -24,6 +24,7 @@ import org.drools.workbench.models.commons.backend.rule.RuleModelDRLPersistenceI
 import org.drools.workbench.models.datamodel.rule.RuleModel;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
 import org.drools.workbench.screens.guided.rule.type.GuidedRuleDSLRResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
@@ -52,6 +53,9 @@ public class GuidedRuleEditorRenameHelper implements RenameHelper {
 
     @Inject
     private GuidedRuleEditorServiceUtilities utilities;
+
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
 
     @Override
     public boolean supports( final Path destination ) {
@@ -85,7 +89,7 @@ public class GuidedRuleEditorRenameHelper implements RenameHelper {
         //Save file
         ioService.write( _destination,
                          RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceUtilities.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorServiceUtilities.java
@@ -96,21 +96,4 @@ public class GuidedRuleEditorServiceUtilities {
         }
         return globals;
     }
-
-    /**
-     * Make a CommentedOption
-     * @param commitMessage
-     * @return
-     */
-    public CommentedOption makeCommentedOption( final String commitMessage ) {
-        final String name = identity.getIdentifier();
-        final Date when = new Date();
-        final CommentedOption co = new CommentedOption( sessionInfo.getId(),
-                                                        name,
-                                                        null,
-                                                        commitMessage,
-                                                        when );
-        return co;
-    }
-
 }

--- a/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-scorecard-editor/drools-wb-guided-scorecard-editor-backend/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>guvnor-services-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-services-backend</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorCopyHelper.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorCopyHelper.java
@@ -21,8 +21,8 @@ import javax.inject.Named;
 
 import org.drools.workbench.models.guided.template.backend.RuleTemplateModelXMLPersistenceImpl;
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
-import org.drools.workbench.screens.guided.rule.backend.server.GuidedRuleEditorServiceUtilities;
 import org.drools.workbench.screens.guided.template.type.GuidedRuleTemplateResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.backend.service.helper.CopyHelper;
@@ -39,15 +39,15 @@ public class GuidedRuleTemplateEditorCopyHelper implements CopyHelper {
     private GuidedRuleTemplateResourceTypeDefinition resourceType;
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
-    private GuidedRuleEditorServiceUtilities utilities;
+    private CommentedOptionFactory commentedOptionFactory;
 
     @Override
     public boolean supports( final Path destination ) {
-        return ( resourceType.accept( destination ) );
+        return (resourceType.accept( destination ));
     }
 
     @Override
@@ -66,7 +66,7 @@ public class GuidedRuleTemplateEditorCopyHelper implements CopyHelper {
         //Save file
         ioService.write( _destination,
                          RuleTemplateModelXMLPersistenceImpl.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-template-editor/drools-wb-guided-template-editor-backend/src/main/java/org/drools/workbench/screens/guided/template/server/GuidedRuleTemplateEditorRenameHelper.java
@@ -23,6 +23,7 @@ import org.drools.workbench.models.guided.template.backend.RuleTemplateModelXMLP
 import org.drools.workbench.models.guided.template.shared.TemplateModel;
 import org.drools.workbench.screens.guided.rule.backend.server.GuidedRuleEditorServiceUtilities;
 import org.drools.workbench.screens.guided.template.type.GuidedRuleTemplateResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
@@ -40,7 +41,7 @@ public class GuidedRuleTemplateEditorRenameHelper implements RenameHelper {
     private GuidedRuleTemplateResourceTypeDefinition resourceType;
 
     @Inject
-    @Named("ioStrategy")
+    @Named( "ioStrategy" )
     private IOService ioService;
 
     @Inject
@@ -49,9 +50,12 @@ public class GuidedRuleTemplateEditorRenameHelper implements RenameHelper {
     @Inject
     private GuidedRuleEditorServiceUtilities utilities;
 
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
+
     @Override
     public boolean supports( final Path destination ) {
-        return ( resourceType.accept( destination ) );
+        return (resourceType.accept( destination ));
     }
 
     @Override
@@ -70,7 +74,7 @@ public class GuidedRuleTemplateEditorRenameHelper implements RenameHelper {
         //Save file
         ioService.write( _destination,
                          RuleTemplateModelXMLPersistenceImpl.getInstance().marshal( model ),
-                         utilities.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
+                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
     }
 
 }

--- a/drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-backend/src/main/java/org/drools/workbench/screens/scorecardxls/backend/server/ScoreCardXLSServiceImpl.java
+++ b/drools-wb-screens/drools-wb-scorecard-xls-editor/drools-wb-scorecard-xls-editor-backend/src/main/java/org/drools/workbench/screens/scorecardxls/backend/server/ScoreCardXLSServiceImpl.java
@@ -19,7 +19,6 @@ package org.drools.workbench.screens.scorecardxls.backend.server;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -31,6 +30,7 @@ import org.drools.workbench.screens.scorecardxls.service.ScoreCardXLSContent;
 import org.drools.workbench.screens.scorecardxls.service.ScoreCardXLSService;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.file.JavaFileFilter;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
 import org.guvnor.common.services.backend.validation.GenericValidator;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.guvnor.common.services.shared.validation.model.ValidationMessage;
@@ -45,7 +45,6 @@ import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
 import org.uberfire.io.IOService;
-import org.uberfire.java.nio.base.options.CommentedOption;
 import org.uberfire.java.nio.file.StandardOpenOption;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.ResourceOpenedEvent;
@@ -84,6 +83,9 @@ public class ScoreCardXLSServiceImpl
 
     @Inject
     private GenericValidator genericValidator;
+
+    @Inject
+    private CommentedOptionFactory commentedOptionFactory;
 
     @Override
     public ScoreCardXLSContent loadContent( final Path path ) {
@@ -134,8 +136,8 @@ public class ScoreCardXLSServiceImpl
             final org.uberfire.java.nio.file.Path nioPath = Paths.convert( resource );
             ioService.createFile( nioPath );
             final OutputStream outputStream = ioService.newOutputStream( nioPath,
-                                                                         makeCommentedOption( sessionId,
-                                                                                              comment ) );
+                                                                         commentedOptionFactory.makeCommentedOption( sessionId,
+                                                                                                                     comment ) );
             IOUtils.copy( content,
                           outputStream );
             outputStream.flush();
@@ -164,8 +166,8 @@ public class ScoreCardXLSServiceImpl
         try {
             final org.uberfire.java.nio.file.Path nioPath = Paths.convert( resource );
             final OutputStream outputStream = ioService.newOutputStream( nioPath,
-                                                                         makeCommentedOption( sessionId,
-                                                                                              comment ) );
+                                                                         commentedOptionFactory.makeCommentedOption( sessionId,
+                                                                                                                     comment ) );
             IOUtils.copy( content,
                           outputStream );
             outputStream.flush();
@@ -238,18 +240,6 @@ public class ScoreCardXLSServiceImpl
         } catch ( Exception e ) {
             throw ExceptionUtilities.handleException( e );
         }
-    }
-
-    private CommentedOption makeCommentedOption( final String sessionId,
-                                                 final String commitMessage ) {
-        final String name = identity.getIdentifier();
-        final Date when = new Date();
-        final CommentedOption co = new CommentedOption( sessionId,
-                                                        name,
-                                                        null,
-                                                        commitMessage,
-                                                        when );
-        return co;
     }
 
 }

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/KSessionSelectorTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/KSessionSelectorTest.java
@@ -353,7 +353,8 @@ public class KSessionSelectorTest {
                 return false;
             }
 
-            @Override public Path setUpKModuleStructure(Path projectRoot) {
+            @Override
+            public Path setUpKModule( final Path path ) {
                 return null;
             }
 

--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -773,11 +773,6 @@
       <artifactId>errai-security-picketlink</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-security-server</artifactId>
-    </dependency>
-
     <!-- Errai AS -->
     <dependency>
       <groupId>org.jboss.errai</groupId>


### PR DESCRIPTION
Scope is no longer editable in the dependency grid.
You can white list the packages in the listed jar or remove from the white list.
Transient dependencies are also listed.
Packages in the current project are always white listed, but everything else needs to be added.
Also removed some redundant code and split few classes into smaller units.

https://github.com/droolsjbpm/kie-docs/pull/32
https://github.com/droolsjbpm/guvnor/pull/219
https://github.com/droolsjbpm/kie-wb-common/pull/202
https://github.com/droolsjbpm/drools-wb/pull/108
https://github.com/droolsjbpm/jbpm-console-ng/pull/261
https://github.com/droolsjbpm/jbpm-form-modeler/pull/32