### PR TITLE
[6.4.x] GUVNOR-2372: Guided Rule Editor: Copying/Renaming rules containing 'modify(x) {..' fails

### DIFF
--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelper.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelper.java
@@ -38,28 +38,35 @@ import org.uberfire.workbench.type.FileNameUtil;
 @ApplicationScoped
 public class GuidedRuleEditorCopyHelper implements CopyHelper {
 
-    @Inject
-    private GuidedRuleDRLResourceTypeDefinition drlResourceType;
-
-    @Inject
-    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType;
-
-    @Inject
-    @Named( "ioStrategy" )
     private IOService ioService;
-
-    @Inject
+    private GuidedRuleDRLResourceTypeDefinition drlResourceType;
+    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType;
+    private GuidedRuleEditorServiceUtilities utilities;
+    private CommentedOptionFactory commentedOptionFactory;
     private DataModelService dataModelService;
 
-    @Inject
-    private GuidedRuleEditorServiceUtilities utilities;
+    public GuidedRuleEditorCopyHelper() {
+        //Zero-parameter constructor for CDI proxies
+    }
 
     @Inject
-    private CommentedOptionFactory commentedOptionFactory;
+    public GuidedRuleEditorCopyHelper( final @Named("ioStrategy") IOService ioService,
+                                       final GuidedRuleDRLResourceTypeDefinition drlResourceType,
+                                       final GuidedRuleDSLRResourceTypeDefinition dslrResourceType,
+                                       final GuidedRuleEditorServiceUtilities utilities,
+                                       final CommentedOptionFactory commentedOptionFactory,
+                                       final DataModelService dataModelService ) {
+        this.ioService = ioService;
+        this.drlResourceType = drlResourceType;
+        this.dslrResourceType = dslrResourceType;
+        this.utilities = utilities;
+        this.commentedOptionFactory = commentedOptionFactory;
+        this.dataModelService = dataModelService;
+    }
 
     @Override
     public boolean supports( final Path destination ) {
-        return (drlResourceType.accept( destination ) || dslrResourceType.accept( destination ));
+        return ( drlResourceType.accept( destination ) || dslrResourceType.accept( destination ) );
     }
 
     @Override
@@ -71,25 +78,31 @@ public class GuidedRuleEditorCopyHelper implements CopyHelper {
         final String[] dsls = utilities.loadDslsForPackage( destination );
         final List<String> globals = utilities.loadGlobalsForPackage( destination );
 
-        final RuleModel model = RuleModelDRLPersistenceImpl.getInstance().unmarshalUsingDSL( drl,
-                                                                                             globals,
-                                                                                             dataModelService.getDataModel( destination ),
-                                                                                             dsls );
         //Update rule name
-        String ruleName = model.name;
+        RuleModel model = null;
+        String ruleName = null;
         if ( drlResourceType.accept( destination ) ) {
+            model = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                         globals,
+                                                                         dataModelService.getDataModel( destination ) );
             ruleName = FileNameUtil.removeExtension( destination,
                                                      drlResourceType );
         } else if ( dslrResourceType.accept( destination ) ) {
+            model = RuleModelDRLPersistenceImpl.getInstance().unmarshalUsingDSL( drl,
+                                                                                 globals,
+                                                                                 dataModelService.getDataModel( destination ),
+                                                                                 dsls );
             ruleName = FileNameUtil.removeExtension( destination,
                                                      dslrResourceType );
         }
-        model.name = ruleName;
 
-        //Save file
-        ioService.write( _destination,
-                         RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
-                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+        if ( model != null ) {
+            //Save file
+            model.name = ruleName;
+            ioService.write( _destination,
+                             RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
+                             commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+        }
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
@@ -38,24 +38,31 @@ import org.uberfire.workbench.type.FileNameUtil;
 @ApplicationScoped
 public class GuidedRuleEditorRenameHelper implements RenameHelper {
 
-    @Inject
-    private GuidedRuleDRLResourceTypeDefinition drlResourceType;
-
-    @Inject
-    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType;
-
-    @Inject
-    @Named("ioStrategy")
     private IOService ioService;
-
-    @Inject
+    private GuidedRuleDRLResourceTypeDefinition drlResourceType;
+    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType;
+    private GuidedRuleEditorServiceUtilities utilities;
+    private CommentedOptionFactory commentedOptionFactory;
     private DataModelService dataModelService;
 
-    @Inject
-    private GuidedRuleEditorServiceUtilities utilities;
+    public GuidedRuleEditorRenameHelper() {
+        //Zero-parameter constructor for CDI proxies
+    }
 
     @Inject
-    private CommentedOptionFactory commentedOptionFactory;
+    public GuidedRuleEditorRenameHelper( final @Named("ioStrategy") IOService ioService,
+                                         final GuidedRuleDRLResourceTypeDefinition drlResourceType,
+                                         final GuidedRuleDSLRResourceTypeDefinition dslrResourceType,
+                                         final GuidedRuleEditorServiceUtilities utilities,
+                                         final CommentedOptionFactory commentedOptionFactory,
+                                         final DataModelService dataModelService ) {
+        this.ioService = ioService;
+        this.drlResourceType = drlResourceType;
+        this.dslrResourceType = dslrResourceType;
+        this.utilities = utilities;
+        this.commentedOptionFactory = commentedOptionFactory;
+        this.dataModelService = dataModelService;
+    }
 
     @Override
     public boolean supports( final Path destination ) {
@@ -71,25 +78,31 @@ public class GuidedRuleEditorRenameHelper implements RenameHelper {
         final String[] dsls = utilities.loadDslsForPackage( destination );
         final List<String> globals = utilities.loadGlobalsForPackage( destination );
 
-        final RuleModel model = RuleModelDRLPersistenceImpl.getInstance().unmarshalUsingDSL( drl,
-                                                                                             globals,
-                                                                                             dataModelService.getDataModel( destination ),
-                                                                                             dsls );
         //Update rule name
-        String ruleName = model.name;
+        RuleModel model = null;
+        String ruleName = null;
         if ( drlResourceType.accept( destination ) ) {
+            model = RuleModelDRLPersistenceImpl.getInstance().unmarshal( drl,
+                                                                         globals,
+                                                                         dataModelService.getDataModel( destination ) );
             ruleName = FileNameUtil.removeExtension( destination,
                                                      drlResourceType );
         } else if ( dslrResourceType.accept( destination ) ) {
+            model = RuleModelDRLPersistenceImpl.getInstance().unmarshalUsingDSL( drl,
+                                                                                 globals,
+                                                                                 dataModelService.getDataModel( destination ),
+                                                                                 dsls );
             ruleName = FileNameUtil.removeExtension( destination,
                                                      dslrResourceType );
         }
-        model.name = ruleName;
 
-        //Save file
-        ioService.write( _destination,
-                         RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
-                         commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
+        if ( model != null ) {
+            //Save file
+            model.name = ruleName;
+            ioService.write( _destination,
+                             RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
+                             commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
+        }
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorCopyHelperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.backend.server;
+
+import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
+import org.drools.workbench.screens.guided.rule.type.GuidedRuleDSLRResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.base.options.CommentedOption;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedRuleEditorCopyHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private GuidedRuleEditorServiceUtilities utilities;
+
+    @Mock
+    private CommentedOptionFactory commentedOptionFactory;
+
+    @Mock
+    private DataModelService dataModelService;
+
+    private GuidedRuleEditorCopyHelper helper;
+    private GuidedRuleDRLResourceTypeDefinition drlResourceType = new GuidedRuleDRLResourceTypeDefinition();
+    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType = new GuidedRuleDSLRResourceTypeDefinition();
+
+    private final String drl = "rule \"rule\"\n" +
+            "when\n" +
+            "$p : Person()\n" +
+            "then\n" +
+            "modify( $p ) {\n" +
+            "}\n" +
+            "end";
+
+    private final String dslr = "rule \"rule\"\n" +
+            "when\n" +
+            ">$p : Person()\n" +
+            "then\n" +
+            ">modify( $p ) {\n" +
+            ">}\n" +
+            "end";
+
+    private String[] dsls = new String[]{ "There is a person=Person()" };
+
+    @Before
+    public void setup() {
+        helper = new GuidedRuleEditorCopyHelper( ioService,
+                                                 drlResourceType,
+                                                 dslrResourceType,
+                                                 utilities,
+                                                 commentedOptionFactory,
+                                                 dataModelService );
+        when( utilities.loadDslsForPackage( any( Path.class ) ) ).thenReturn( dsls );
+    }
+
+    @Test
+    public void testRDRLFile() {
+        final Path pathSource = mock( Path.class );
+        final Path pathDestination = mock( Path.class );
+        when( pathSource.toURI() ).thenReturn( "default://p0/src/main/resources/MyFile.rdrl" );
+        when( pathDestination.toURI() ).thenReturn( "default://p0/src/main/resources/MyNewFile.rdrl" );
+        when( pathDestination.getFileName() ).thenReturn( "MyNewFile.rdrl" );
+        when( ioService.readAllString( any( org.uberfire.java.nio.file.Path.class ) ) ).thenReturn( drl );
+
+        helper.postProcess( pathSource,
+                            pathDestination );
+
+        final ArgumentCaptor<String> drlArgumentCaptor = ArgumentCaptor.forClass( String.class );
+        verify( ioService,
+                times( 1 ) ).write( any( org.uberfire.java.nio.file.Path.class ),
+                                    drlArgumentCaptor.capture(),
+                                    any( CommentedOption.class ) );
+
+        final String newDrl = drlArgumentCaptor.getValue();
+        assertNotNull( newDrl );
+        assertTrue( newDrl.contains( "MyNewFile" ) );
+    }
+
+    @Test
+    public void testRDSLRFile() {
+        final Path pathSource = mock( Path.class );
+        final Path pathDestination = mock( Path.class );
+        when( pathSource.toURI() ).thenReturn( "default://p0/src/main/resources/MyFile.rdslr" );
+        when( pathDestination.toURI() ).thenReturn( "default://p0/src/main/resources/MyNewFile.rdslr" );
+        when( pathDestination.getFileName() ).thenReturn( "MyNewFile.rdslr" );
+        when( ioService.readAllString( any( org.uberfire.java.nio.file.Path.class ) ) ).thenReturn( dslr );
+
+        helper.postProcess( pathSource,
+                            pathDestination );
+
+        final ArgumentCaptor<String> drlArgumentCaptor = ArgumentCaptor.forClass( String.class );
+        verify( ioService,
+                times( 1 ) ).write( any( org.uberfire.java.nio.file.Path.class ),
+                                    drlArgumentCaptor.capture(),
+                                    any( CommentedOption.class ) );
+
+        final String newDrl = drlArgumentCaptor.getValue();
+        assertNotNull( newDrl );
+        assertTrue( newDrl.contains( "MyNewFile" ) );
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/test/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelperTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.backend.server;
+
+import org.drools.workbench.screens.guided.rule.type.GuidedRuleDRLResourceTypeDefinition;
+import org.drools.workbench.screens.guided.rule.type.GuidedRuleDSLRResourceTypeDefinition;
+import org.guvnor.common.services.backend.util.CommentedOptionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodel.backend.server.service.DataModelService;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.base.options.CommentedOption;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedRuleEditorRenameHelperTest {
+
+    @Mock
+    private IOService ioService;
+
+    @Mock
+    private GuidedRuleEditorServiceUtilities utilities;
+
+    @Mock
+    private CommentedOptionFactory commentedOptionFactory;
+
+    @Mock
+    private DataModelService dataModelService;
+
+    private GuidedRuleEditorRenameHelper helper;
+    private GuidedRuleDRLResourceTypeDefinition drlResourceType = new GuidedRuleDRLResourceTypeDefinition();
+    private GuidedRuleDSLRResourceTypeDefinition dslrResourceType = new GuidedRuleDSLRResourceTypeDefinition();
+
+    private final String drl = "rule \"rule\"\n" +
+            "when\n" +
+            "$p : Person()\n" +
+            "then\n" +
+            "modify( $p ) {\n" +
+            "}\n" +
+            "end";
+
+    private final String dslr = "rule \"rule\"\n" +
+            "when\n" +
+            ">$p : Person()\n" +
+            "then\n" +
+            ">modify( $p ) {\n" +
+            ">}\n" +
+            "end";
+
+    private String[] dsls = new String[]{ "There is a person=Person()" };
+
+    @Before
+    public void setup() {
+        helper = new GuidedRuleEditorRenameHelper( ioService,
+                                                   drlResourceType,
+                                                   dslrResourceType,
+                                                   utilities,
+                                                   commentedOptionFactory,
+                                                   dataModelService );
+        when( utilities.loadDslsForPackage( any( Path.class ) ) ).thenReturn( dsls );
+    }
+
+    @Test
+    public void testRDRLFile() {
+        final Path pathSource = mock( Path.class );
+        final Path pathDestination = mock( Path.class );
+        when( pathSource.toURI() ).thenReturn( "default://p0/src/main/resources/MyFile.rdrl" );
+        when( pathDestination.toURI() ).thenReturn( "default://p0/src/main/resources/MyNewFile.rdrl" );
+        when( pathDestination.getFileName() ).thenReturn( "MyNewFile.rdrl" );
+        when( ioService.readAllString( any( org.uberfire.java.nio.file.Path.class ) ) ).thenReturn( drl );
+
+        helper.postProcess( pathSource,
+                            pathDestination );
+
+        final ArgumentCaptor<String> drlArgumentCaptor = ArgumentCaptor.forClass( String.class );
+        verify( ioService,
+                times( 1 ) ).write( any( org.uberfire.java.nio.file.Path.class ),
+                                    drlArgumentCaptor.capture(),
+                                    any( CommentedOption.class ) );
+
+        final String newDrl = drlArgumentCaptor.getValue();
+        assertNotNull( newDrl );
+        assertTrue( newDrl.contains( "MyNewFile" ) );
+    }
+
+    @Test
+    public void testRDSLRFile() {
+        final Path pathSource = mock( Path.class );
+        final Path pathDestination = mock( Path.class );
+        when( pathSource.toURI() ).thenReturn( "default://p0/src/main/resources/MyFile.rdslr" );
+        when( pathDestination.toURI() ).thenReturn( "default://p0/src/main/resources/MyNewFile.rdslr" );
+        when( pathDestination.getFileName() ).thenReturn( "MyNewFile.rdslr" );
+        when( ioService.readAllString( any( org.uberfire.java.nio.file.Path.class ) ) ).thenReturn( dslr );
+
+        helper.postProcess( pathSource,
+                            pathDestination );
+
+        final ArgumentCaptor<String> drlArgumentCaptor = ArgumentCaptor.forClass( String.class );
+        verify( ioService,
+                times( 1 ) ).write( any( org.uberfire.java.nio.file.Path.class ),
+                                    drlArgumentCaptor.capture(),
+                                    any( CommentedOption.class ) );
+
+        final String newDrl = drlArgumentCaptor.getValue();
+        assertNotNull( newDrl );
+        assertTrue( newDrl.contains( "MyNewFile" ) );
+    }
+
+}


### PR DESCRIPTION
Corollary of https://github.com/droolsjbpm/drools-wb/pull/118
 
(cherry picked from commit 628d5b417a82852f3edfc0c1134982c91fea60b4)