### PR TITLE
GUVNOR-2372: Guided Rule Editor: Copying/Renaming rules containing 'modify(x) {..' fails. Fixed log message for 'Renaming'

### DIFF
--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-backend/src/main/java/org/drools/workbench/screens/guided/rule/backend/server/GuidedRuleEditorRenameHelper.java
@@ -101,7 +101,7 @@ public class GuidedRuleEditorRenameHelper implements RenameHelper {
             model.name = ruleName;
             ioService.write( _destination,
                              RuleModelDRLPersistenceImpl.getInstance().marshal( model ),
-                             commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] copied to [" + destination.toURI() + "]." ) );
+                             commentedOptionFactory.makeCommentedOption( "File [" + source.toURI() + "] renamed to [" + destination.toURI() + "]." ) );
         }
     }
 


### PR DESCRIPTION
Fixed log message (reported by community on IRC).