### PR TITLE
[6.4.x] BZ1301051: Column values are deleted after changing the operator in a Guided Decision Table

### DIFF
--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTablePopulater.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/GuidedDecisionTablePopulater.java
@@ -270,7 +270,7 @@ public class GuidedDecisionTablePopulater {
             for ( int iRow = columnData.size(); iRow < maxRowCount; iRow++ ) {
                 final List<DTCellValue52> brlFragmentData = new ArrayList<DTCellValue52>();
                 for ( int iCol = 0; iCol < parameters.size(); iCol++ ) {
-                    brlFragmentData.add( new DTCellValue52() );
+                    brlFragmentData.add( new DTCellValue52( ) );
                 }
                 columnData.add( brlFragmentData );
             }

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDateEffectiveBuilder.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDateEffectiveBuilder.java
@@ -58,9 +58,10 @@ public class GuidedDecisionTableDateEffectiveBuilder extends AbstractGuidedDecis
     public void addCellValue( final int row,
                               final int column,
                               final String value ) {
-        final DTCellValue52 dcv = new DTCellValue52();
+        final DTCellValue52 dcv = new DTCellValue52( "" );
         try {
             dcv.setStringValue( value );
+
         } catch ( IllegalArgumentException iae ) {
             final String message = "Date-Effective is not a date literal, in cell " + RuleSheetParserUtil.rc2name( row,
                                                                                                                    column );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDateExpiresBuilder.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDateExpiresBuilder.java
@@ -59,9 +59,10 @@ public class GuidedDecisionTableDateExpiresBuilder extends AbstractGuidedDecisio
     public void addCellValue( final int row,
                               final int column,
                               final String value ) {
-        final DTCellValue52 dcv = new DTCellValue52();
+        final DTCellValue52 dcv = new DTCellValue52( "" );
         try {
             dcv.setStringValue( value );
+
         } catch ( IllegalArgumentException iae ) {
             final String message = "Date-Expires is not a date literal, in cell " + RuleSheetParserUtil.rc2name( row,
                                                                                                                  column );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDurationBuilder.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableDurationBuilder.java
@@ -46,7 +46,8 @@ public class GuidedDecisionTableDurationBuilder extends AbstractGuidedDecisionTa
 
         if ( this.values.size() < maxRowCount ) {
             for ( int iRow = this.values.size(); iRow < maxRowCount; iRow++ ) {
-                this.values.add( new DTCellValue52( Long.valueOf( "" ) ) );
+                final DTCellValue52 dcv = new DTCellValue52( 0 );
+                this.values.add( dcv );
             }
         }
 
@@ -58,9 +59,10 @@ public class GuidedDecisionTableDurationBuilder extends AbstractGuidedDecisionTa
     public void addCellValue( final int row,
                               final int column,
                               final String value ) {
-        final DTCellValue52 dcv = new DTCellValue52();
+        final DTCellValue52 dcv = new DTCellValue52( 0 );
         try {
             dcv.setNumericValue( Long.valueOf( value ) );
+
         } catch ( NumberFormatException nfe ) {
             final String message = "Duration is not an long literal, in cell " + RuleSheetParserUtil.rc2name( row,
                                                                                                               column );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableSalienceBuilder.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/GuidedDecisionTableSalienceBuilder.java
@@ -61,7 +61,8 @@ public class GuidedDecisionTableSalienceBuilder extends AbstractGuidedDecisionTa
 
         if ( this.values.size() < maxRowCount ) {
             for ( int iRow = this.values.size(); iRow < maxRowCount; iRow++ ) {
-                this.values.add( new DTCellValue52( Integer.valueOf( "" ) ) );
+                final DTCellValue52 dcv = new DTCellValue52( 0 );
+                this.values.add( dcv );
             }
         }
 
@@ -78,9 +79,10 @@ public class GuidedDecisionTableSalienceBuilder extends AbstractGuidedDecisionTa
             value = value.substring( 1,
                                      value.lastIndexOf( ")" ) - 1 );
         }
-        final DTCellValue52 dcv = new DTCellValue52();
+        final DTCellValue52 dcv = new DTCellValue52( 0 );
         try {
             dcv.setNumericValue( Integer.valueOf( value ) );
+
         } catch ( NumberFormatException nfe ) {
             final String message = "Priority is not an integer literal, in cell " + RuleSheetParserUtil.rc2name( row,
                                                                                                                  column );

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/RowNumberBuilder.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/main/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/builders/RowNumberBuilder.java
@@ -36,7 +36,7 @@ public class RowNumberBuilder
                                        final int maxRowCount ) {
         if ( this.values.size() < maxRowCount ) {
             for ( int iRow = this.values.size(); iRow < maxRowCount; iRow++ ) {
-                this.values.add( new DTCellValue52() );
+                this.values.add( new DTCellValue52( 0 ) );
             }
         }
 
@@ -53,7 +53,7 @@ public class RowNumberBuilder
     public void addCellValue( final int row,
                               final int col,
                               final String value ) {
-        this.values.add( new DTCellValue52() );
+        this.values.add( new DTCellValue52( 0 ) );
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/src/test/java/org/drools/workbench/screens/dtablexls/backend/server/conversion/DecisionTableXLSToDecisionTableGuidedConverterTest.java
@@ -200,9 +200,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Specific rule 1", "1", "g1", "100", "T1", "CAL1", "TRUE", "TRUE", "TRUE", "AG1", "RFG1" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Specific rule 1", 1, "g1", 100l, "T1", "CAL1", true, true, true, "AG1", "RFG1" },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Specific rule 2", "2", "g2", "200", "T2", "CAL2", "FALSE", "FALSE", "FALSE", "AG2", "RFG2" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Specific rule 2", 2, "g2", 200l, "T2", "CAL2", false, false, false, "AG2", "RFG2" },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -265,9 +265,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 8", "2" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 8", 2 },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 9", "1" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 9", 1 },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -336,9 +336,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", 0 },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", 0 },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -407,9 +407,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", 0 },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", 0 },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -470,9 +470,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "cheddar" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", "cheddar" },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "edam" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", "edam" },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -659,32 +659,32 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "10", "20", "30", "hello", "TRUE" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", "10", "20", "30", "hello", true },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "50", "60", "70", "goodbye", "FALSE" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", "50", "60", "70", "goodbye", false },
                                      dtable.getData().get( 1 ) ) );
     }
 
     @Test
     public void testConditions() {
-        final List<String[]> expectedRows = new ArrayList<String[]>( 2 );
-        expectedRows.add( new String[]{ "1", "Created from row 7", "20", "Mike", "Brown", "BMW", "M3" } );
-        expectedRows.add( new String[]{ "2", "Created from row 8", "30", "Jason", "Grey", "Audi", "S4" } );
+        final List<Object[]> expectedRows = new ArrayList<Object[]>( 2 );
+        expectedRows.add( new Object[]{ 1, "Created from row 7", 20, "Mike", "Brown", "BMW", "M3" } );
+        expectedRows.add( new Object[]{ 2, "Created from row 8", 30, "Jason", "Grey", "Audi", "S4" } );
         conditionsTest( "Conditions.xls",
                         expectedRows );
     }
 
     @Test
     public void testConditionsIndexedParameters() {
-        final List<String[]> expectedRows = new ArrayList<String[]>( 2 );
-        expectedRows.add( new String[]{ "1", "Created from row 7", "20", "Mike", "Brown", "BMW", "M3" } );
-        expectedRows.add( new String[]{ "2", "Created from row 8", "30", "Jason", "Grey", "", "" } );
+        final List<Object[]> expectedRows = new ArrayList<Object[]>( 2 );
+        expectedRows.add( new Object[]{ 1, "Created from row 7", 20, "Mike", "Brown", "BMW", "M3" } );
+        expectedRows.add( new Object[]{ 2, "Created from row 8", 30, "Jason", "Grey", "", "" } );
         conditionsTest( "Conditions-indexedParameters.xls",
                         expectedRows );
     }
 
     private void conditionsTest( final String xlsFileName,
-                                 final List<String[]> expectedRows ) {
+                                 final List<Object[]> expectedRows ) {
         final ConversionResult result = new ConversionResult();
         final List<DataListener> listeners = new ArrayList<DataListener>();
 
@@ -935,7 +935,8 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         assertTrue( expectedRows.size() == 2 );
 
         for ( int i = 0; i < 2; i++ ) {
-            assertTrue( isRowEquivalent( expectedRows.get( i ), dtable.getData().get( i ) ) );
+            assertTrue( isRowEquivalent( expectedRows.get( i ),
+                                         dtable.getData().get( i ) ) );
         }
     }
 
@@ -1073,9 +1074,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable0.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "AG1", "John", "Hello Sir" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", "AG1", "John", "Hello Sir" },
                                      dtable0.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "AG2", "Jane", "Hello Madam" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", "AG2", "Jane", "Hello Madam" },
                                      dtable0.getData().get( 1 ) ) );
 
         //Check expanded columns
@@ -1156,9 +1157,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable1.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 15", "John", "25" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 15", "John", "25" },
                                      dtable1.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 16", "Jane", "29" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 16", "Jane", "29" },
                                      dtable1.getData().get( 1 ) ) );
 
     }
@@ -1247,9 +1248,9 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 2,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 7", "isQualified" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 7", "isQualified" },
                                      dtable.getData().get( 0 ) ) );
-        assertTrue( isRowEquivalent( new String[]{ "2", "Created from row 8", "isLicensed" },
+        assertTrue( isRowEquivalent( new Object[]{ 2, "Created from row 8", "isLicensed" },
                                      dtable.getData().get( 1 ) ) );
     }
 
@@ -1668,7 +1669,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 1,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 10", "false", "", "true", "0" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 10", "false", "", "true", "0" },
                                      dtable.getData().get( 0 ) ) );
     }
 
@@ -1865,7 +1866,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         //Check data
         assertEquals( 1,
                       dtable.getData().size() );
-        assertTrue( isRowEquivalent( new String[]{ "1", "Created from row 10", "false", "true", "false", "false" },
+        assertTrue( isRowEquivalent( new Object[]{ 1, "Created from row 10", false, true, false, false },
                                      dtable.getData().get( 0 ) ) );
     }
 
@@ -1936,7 +1937,7 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
         assertTrue( columns.get( 19 ) instanceof BRLActionVariableColumn );
     }
 
-    private boolean isRowEquivalent( String[] expected,
+    private boolean isRowEquivalent( Object[] expected,
                                      List<DTCellValue52> actual ) {
         //Sizes should match
         if ( expected.length != actual.size() ) {
@@ -1949,60 +1950,60 @@ public class DecisionTableXLSToDecisionTableGuidedConverterTest {
             switch ( dcv.getDataType() ) {
                 case NUMERIC:
                     final BigDecimal numeric = (BigDecimal) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numeric.toPlainString() ) ) {
+                    if ( !expected[ i ].equals( numeric ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_BIGDECIMAL:
                     final BigDecimal numericBigDecimal = (BigDecimal) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericBigDecimal.toPlainString() ) ) {
+                    if ( !expected[ i ].equals( numericBigDecimal ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_BIGINTEGER:
                     final BigInteger numericBigInteger = (BigInteger) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericBigInteger.toString() ) ) {
+                    if ( !expected[ i ].equals( numericBigInteger ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_BYTE:
                     final Byte numericByte = (Byte) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericByte.toString() ) ) {
+                    if ( !expected[ i ].equals( numericByte ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_DOUBLE:
                     final Double numericDouble = (Double) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericDouble.toString() ) ) {
+                    if ( !expected[ i ].equals( numericDouble ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_FLOAT:
                     final Float numericFloat = (Float) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericFloat.toString() ) ) {
+                    if ( !expected[ i ].equals( numericFloat ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_INTEGER:
                     final Integer numericInteger = (Integer) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericInteger.toString() ) ) {
+                    if ( !expected[ i ].equals( numericInteger ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_LONG:
                     final Long numericLong = (Long) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericLong.toString() ) ) {
+                    if ( !expected[ i ].equals( numericLong ) ) {
                         return false;
                     }
                     break;
                 case NUMERIC_SHORT:
                     final Short numericShort = (Short) dcv.getNumericValue();
-                    if ( !expected[ i ].equals( numericShort.toString() ) ) {
+                    if ( !expected[ i ].equals( numericShort ) ) {
                         return false;
                     }
                     break;
                 case BOOLEAN:
-                    if ( Boolean.parseBoolean( expected[ i ] ) != dcv.getBooleanValue() ) {
+                    if ( !expected[ i ].equals( dcv.getBooleanValue() ) ) {
                         return false;
                     }
                     break;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/utils/DTCellValueUtilities.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/utils/DTCellValueUtilities.java
@@ -214,12 +214,14 @@ public class DTCellValueUtilities {
         if ( dcv == null ) {
             return;
         }
-        if ( dcv.getStringValue() == null ) {
-            return;
-        }
-        String[] values = dcv.getStringValue().split( "," );
-        if ( values.length > 0 ) {
-            dcv.setStringValue( values[ 0 ] );
+        if ( dcv.getDataType().equals( DataType.DataTypes.STRING ) ) {
+            if ( dcv.getStringValue() == null ) {
+                return;
+            }
+            String[] values = dcv.getStringValue().split( "," );
+            if ( values.length > 0 ) {
+                dcv.setStringValue( values[ 0 ] );
+            }
         }
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/utils/DTCellValueUtilitiesTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/utils/DTCellValueUtilitiesTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.utils;
+
+import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DTCellValueUtilitiesTest {
+
+    @Mock
+    private GuidedDecisionTable52 model;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracle;
+
+    private DTCellValueUtilities utilities;
+
+    @Before
+    public void setup() {
+        utilities = new DTCellValueUtilities( model,
+                                              oracle );
+    }
+
+    @Test
+    public void testRemoveCommaSeparatedValue() {
+        DTCellValue52 dcv;
+
+        dcv = new DTCellValue52( 1 );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( 1,
+                      dcv.getNumericValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getStringValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.NUMERIC_INTEGER,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( 1L );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( 1L,
+                      dcv.getNumericValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getStringValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.NUMERIC_LONG,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( 1.0 );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( 1.0,
+                      dcv.getNumericValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getStringValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.NUMERIC_DOUBLE,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( "Fred" );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( "Fred",
+                      dcv.getStringValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getNumericValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.STRING,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( "Fred,Ginger" );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( "Fred",
+                      dcv.getStringValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getNumericValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.STRING,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( ",Ginger" );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( "",
+                      dcv.getStringValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getNumericValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.STRING,
+                      dcv.getDataType() );
+
+        dcv = new DTCellValue52( "Fred," );
+        utilities.removeCommaSeparatedValue( dcv );
+        assertEquals( "Fred",
+                      dcv.getStringValue() );
+        assertNull( dcv.getBooleanValue() );
+        assertNull( dcv.getNumericValue() );
+        assertNull( dcv.getDateValue() );
+        assertEquals( DataType.DataTypes.STRING,
+                      dcv.getDataType() );
+    }
+
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1301051

This is the corollary of https://github.com/droolsjbpm/drools-wb/pull/127 for 6.4.x

(cherry picked from commit 9058ac86dcc15f50fac7bb8edf915cef3b1df606)