### PR TITLE
cleanup in DecisionTableXLSServiceImpl & ScoreCardXLSServiceImpl

### DIFF
--- a/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-dtable-xls-editor/drools-wb-dtable-xls-editor-backend/pom.xml
@@ -230,7 +230,16 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
- close input/output streams
- avoid code duplication
- unify exception handling
- add validation when saving xls dt
- and also properly close the Workbook created as a means of validation
- use File instead of InputStream for the Workbook creation as it is supposed to be more memory-friendly, see https://poi.apache.org/apidocs/org/apache/poi/ss/usermodel/WorkbookFactory.html#create(java.io.InputStream)

@manstis something for your experienced eye, I think. ;) It _should_ be okay, but you just never know...

This might also help BZ1332961.