### PR TITLE
GUVNOR-2538: Guided Decision Table Editor: Fix handling of UpdatedLockStatusEvent

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/pom.xml
@@ -186,6 +186,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Needed for DataModelOracle builder used in tests -->
     <dependency>
       <groupId>org.kie.workbench.services</groupId>

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -280,9 +280,10 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
                                   afterRemovalCommand );
     }
 
-    private void onUpdatedLockStatusEvent( final @Observes UpdatedLockStatusEvent event ) {
+    void onUpdatedLockStatusEvent( final @Observes UpdatedLockStatusEvent event ) {
+        //Update Lock status on Decision Tables
         for ( GuidedDecisionTableView.Presenter dtPresenter : getAvailableDecisionTables() ) {
-            if ( event.getFile().equals( dtPresenter.getCurrentPath() ) ) {
+            if ( dtPresenter.getCurrentPath().equals( event.getFile() ) ) {
                 if ( event.isLocked() ) {
                     dtPresenter.getAccess().setLocked( !event.isLockedByCurrentUser() );
                 } else {
@@ -291,12 +292,13 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
             }
         }
 
+        //Update Definitions Panel if active Decision Table's lock has changed
         final GuidedDecisionTableView.Presenter dtPresenter = getActiveDecisionTable();
         if ( dtPresenter == null ) {
             return;
         }
-        if ( event.getFile().equals( dtPresenter.getCurrentPath() ) ) {
-            doDecisionTableSelected( dtPresenter );
+        if ( dtPresenter.getCurrentPath().equals( event.getFile() ) ) {
+            refreshDefinitionsPanel( dtPresenter );
         }
     }
 
@@ -319,7 +321,7 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     public boolean isActiveDecisionTableEditable() {
         final GuidedDecisionTableView.Presenter dtPresenter = getActiveDecisionTable();
         if ( dtPresenter == null ) {
-            return true;
+            return false;
         }
         return dtPresenter.getAccess().isEditable();
     }
@@ -380,15 +382,20 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
                                              availableParentRuleNames );
             }
         } );
+        refreshDefinitionsPanel( dtPresenter );
+
+        //Delegate highlighting of selected decision table to ISelectionManager
+        view.select( dtPresenter.getView() );
+    }
+
+    private void refreshDefinitionsPanel( final GuidedDecisionTableView.Presenter dtPresenter ) {
+        final GuidedDecisionTable52 model = dtPresenter.getModel();
         view.setEnableColumnCreation( dtPresenter.getAccess().isEditable() );
         view.refreshAttributeWidget( model.getAttributeCols() );
         view.refreshMetaDataWidget( model.getMetadataCols() );
         view.refreshConditionsWidget( model.getConditions() );
         view.refreshActionsWidget( model.getActionCols() );
         view.refreshColumnsNote( dtPresenter.hasColumnDefinitions() );
-
-        //Delegate highlighting of selected decision table to ISelectionManager
-        view.select( dtPresenter.getView() );
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table;
+
+import javax.enterprise.event.Event;
+
+import org.drools.workbench.screens.guided.dtable.client.editor.menu.CellContextMenu;
+import org.drools.workbench.screens.guided.dtable.client.editor.menu.RadarMenuBuilder;
+import org.drools.workbench.screens.guided.dtable.client.editor.menu.RowContextMenu;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTablePinnedEvent;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.mvp.UpdatedLockStatusEvent;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.PlaceRequest;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedDecisionTableModellerPresenterTest {
+
+    @Mock
+    private GuidedDecisionTableModellerView view;
+
+    private Event<RadarMenuBuilder.UpdateRadarEvent> updateRadarEvent = new EventSourceMock<>();
+
+    private Event<DecisionTablePinnedEvent> pinnedEvent = new EventSourceMock<>();
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Mock
+    private SyncBeanDef<GuidedDecisionTableView.Presenter> dtableBeanDef;
+
+    @Mock
+    private GuidedDecisionTableView.Presenter dtablePresenter;
+
+    @Mock
+    private GuidedDecisionTableView dtableView;
+
+    @Mock
+    private CellContextMenu cellContextMenu;
+
+    @Mock
+    private RowContextMenu rowContextMenu;
+
+    private GuidedDecisionTableModellerPresenter presenter;
+
+    @Before
+    public void setup() {
+        presenter = new GuidedDecisionTableModellerPresenter( view,
+                                                              updateRadarEvent,
+                                                              pinnedEvent,
+                                                              beanManager,
+                                                              cellContextMenu,
+                                                              rowContextMenu );
+        when( beanManager.lookupBean( GuidedDecisionTableView.Presenter.class ) ).thenReturn( dtableBeanDef );
+        when( dtableBeanDef.getInstance() ).thenReturn( dtablePresenter );
+        when( dtableBeanDef.newInstance() ).thenReturn( dtablePresenter );
+        when( dtablePresenter.getView() ).thenReturn( dtableView );
+    }
+
+    @Test
+    public void testOnUpdatedLockStatusEvent_NonNullFile() {
+        final ObservablePath dtPath = mock( ObservablePath.class );
+        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
+        final GuidedDecisionTableEditorContent dtContent = mock( GuidedDecisionTableEditorContent.class );
+
+        final GuidedDecisionTableView.Presenter dtPresenter = presenter.addDecisionTable( dtPath,
+                                                                                          dtPlaceRequest,
+                                                                                          dtContent,
+                                                                                          false );
+
+        when( dtPresenter.getCurrentPath() ).thenReturn( dtPath );
+
+        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
+        when( event.getFile() ).thenReturn( mock( Path.class ) );
+        presenter.onUpdatedLockStatusEvent( event );
+    }
+
+    @Test
+    public void testOnUpdatedLockStatusEvent_NullFile() {
+        final ObservablePath dtPath = mock( ObservablePath.class );
+        final PlaceRequest dtPlaceRequest = mock( PlaceRequest.class );
+        final GuidedDecisionTableEditorContent dtContent = mock( GuidedDecisionTableEditorContent.class );
+
+        final GuidedDecisionTableView.Presenter dtPresenter = presenter.addDecisionTable( dtPath,
+                                                                                          dtPlaceRequest,
+                                                                                          dtContent,
+                                                                                          false );
+
+        when( dtPresenter.getCurrentPath() ).thenReturn( dtPath );
+
+        final UpdatedLockStatusEvent event = mock( UpdatedLockStatusEvent.class );
+        presenter.onUpdatedLockStatusEvent( event );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2538

The Workbench breaks at the moment if you try to open any editor whilst a Guided Decision Table editor is open. The JIRA goes into the gory detail of what's wrong (with Uberfire). This fix is the simplest of the two options!