### PR TITLE
PLANNER-579: Reduce WARN messages during startup

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/css/Analysis.css
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/resources/org/drools/workbench/screens/guided/dtable/client/resources/css/Analysis.css
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@CHARSET "UTF-8";
-
 .exampleTable {
     background-color: white;
     font-size: 10px;

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/resources/org/drools/workbench/screens/guided/rule/client/resources/css/GuidedRuleEditor.css
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/resources/org/drools/workbench/screens/guided/rule/client/resources/css/GuidedRuleEditor.css
@@ -1,5 +1,3 @@
-@CHARSET "UTF-8";
-
 .container {
     padding: 0px;
     padding: 0px;


### PR DESCRIPTION
Fixes warnings when starting OptaPlanner WB in Super Dev Mode

         Computing all possible rebind results for 'org.drools.workbench.screens.guided.dtable.client.resources.GuidedDecisionTableResources'
            Rebinding org.drools.workbench.screens.guided.dtable.client.resources.GuidedDecisionTableResources
                        [WARN] Charset declaration detected. A charset at-rule is not relevant inside a style element