### PR TITLE
refactor AttributeSelectorPopup code, add some tests

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableAttributeSelectorPopup.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableAttributeSelectorPopup.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table;
+
+import java.util.Arrays;
+
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
+import org.drools.workbench.screens.guided.rule.client.editor.AttributeSelectorPopup;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
+
+public class GuidedDecisionTableAttributeSelectorPopup extends AttributeSelectorPopup {
+
+    private final String[] existingAttributeNames;
+    private final GuidedDecisionTableView.Presenter presenter;
+
+    public GuidedDecisionTableAttributeSelectorPopup( String[] existingAttributeNames,
+                                                      GuidedDecisionTableView.Presenter presenter ) {
+        this.existingAttributeNames = existingAttributeNames;
+        this.presenter = presenter;
+
+        initialize();
+    }
+
+    @Override
+    protected String[] getAttributes() {
+        String[] attributes = RuleAttributeWidget.getAttributesList();
+        attributes = Arrays.copyOf( attributes, attributes.length + 1 );
+        attributes[attributes.length - 1] = GuidedDecisionTable52.NEGATE_RULE_ATTR;
+        return attributes;
+    }
+
+    @Override
+    protected String[] getDuplicates() {
+        return existingAttributeNames;
+    }
+
+    @Override
+    protected void handleAttributeAddition( String attributeName ) {
+        final AttributeCol52 column = new AttributeCol52();
+        column.setAttribute( attributeName );
+        presenter.appendColumn( column );
+    }
+
+    @Override
+    protected boolean isMetadataUnique( String metadataName ) {
+        return presenter.isMetaDataUnique( metadataName );
+    }
+
+    @Override
+    protected String metadataNotUniqueMessage( String metadataName ) {
+        return GuidedDecisionTableConstants.INSTANCE.ThatColumnNameIsAlreadyInUsePleasePickAnother();
+    }
+
+    @Override
+    protected void handleMetadataAddition( String metadataName ) {
+        final MetadataCol52 column = new MetadataCol52();
+        column.setMetadata( metadataName );
+        column.setHideColumn( true );
+        presenter.appendColumn( column );
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
@@ -24,15 +24,7 @@ import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Rectangle;
 import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.types.Point2D;
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.EventBus;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.ListBox;
-import com.google.gwt.user.client.ui.TextBox;
 import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
@@ -41,7 +33,6 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol5
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetFieldCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLActionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
@@ -53,10 +44,8 @@ import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryAction
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryConditionCol52;
-import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
-import org.drools.workbench.screens.guided.dtable.client.resources.images.GuidedDecisionTableImageResources508;
 import org.drools.workbench.screens.guided.dtable.client.widget.ActionColumnCommand;
 import org.drools.workbench.screens.guided.dtable.client.widget.ActionInsertFactPopup;
 import org.drools.workbench.screens.guided.dtable.client.widget.ActionRetractFactPopup;
@@ -71,11 +60,8 @@ import org.drools.workbench.screens.guided.dtable.client.widget.ConditionPopup;
 import org.drools.workbench.screens.guided.dtable.client.widget.LimitedEntryBRLActionColumnViewImpl;
 import org.drools.workbench.screens.guided.dtable.client.widget.LimitedEntryBRLConditionColumnViewImpl;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.themes.GuidedDecisionTableTheme;
-import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
 import org.uberfire.ext.widgets.common.client.common.BusyPopup;
-import org.uberfire.ext.widgets.common.client.common.DirtyableHorizontalPane;
-import org.uberfire.ext.widgets.common.client.common.popups.FormStylePopup;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.util.CoordinateTransformationUtils;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
@@ -210,69 +196,8 @@ public class GuidedDecisionTableViewImpl extends BaseGridWidget implements Guide
 
     @Override
     public void newAttributeOrMetaDataColumn() {
-        // show choice of attributes
-        final Image image = GuidedDecisionTableImageResources508.INSTANCE.Config();
-        final FormStylePopup pop = new FormStylePopup( image,
-                                                       GuidedDecisionTableConstants.INSTANCE.AddAnOptionToTheRule() );
-        final ListBox list = RuleAttributeWidget.getAttributeList();
-
-        //This attribute is only used for Decision Tables
-        list.addItem( GuidedDecisionTable52.NEGATE_RULE_ATTR );
-
-        // Remove any attributes already added
-        final Set<String> existingAttributeNames = presenter.getExistingAttributeNames();
-        for ( String existingAttributeName : existingAttributeNames ) {
-            for ( int iItem = 0; iItem < list.getItemCount(); iItem++ ) {
-                if ( list.getItemText( iItem ).equals( existingAttributeName ) ) {
-                    list.removeItem( iItem );
-                    break;
-                }
-            }
-        }
-
-        //Selection of an Attribute adds it
-        list.setSelectedIndex( 0 );
-        list.addChangeHandler( new ChangeHandler() {
-            public void onChange( ChangeEvent event ) {
-                final String attributeName = list.getSelectedItemText();
-                final AttributeCol52 column = new AttributeCol52();
-                column.setAttribute( attributeName );
-                presenter.appendColumn( column );
-                pop.hide();
-            }
-        } );
-
-        //You have to click "add" to add MetaData.. inconsistent for sure!
-        final TextBox box = new TextBox();
-        box.setVisibleLength( 15 );
-
-        final Image addButton = GuidedDecisionTableImageResources508.INSTANCE.NewItem();
-        addButton.setTitle( GuidedDecisionTableConstants.INSTANCE.AddMetadataToTheRule() );
-        addButton.addClickHandler( new ClickHandler() {
-            public void onClick( ClickEvent w ) {
-
-                final String metaDataName = box.getText();
-                if ( !presenter.isMetaDataUnique( metaDataName ) ) {
-                    Window.alert( GuidedDecisionTableConstants.INSTANCE.ThatColumnNameIsAlreadyInUsePleasePickAnother() );
-                    return;
-                }
-                final MetadataCol52 column = new MetadataCol52();
-                column.setMetadata( metaDataName );
-                column.setHideColumn( true );
-                presenter.appendColumn( column );
-                pop.hide();
-            }
-
-        } );
-        DirtyableHorizontalPane horiz = new DirtyableHorizontalPane();
-        horiz.add( box );
-        horiz.add( addButton );
-
-        pop.addAttribute( new StringBuilder( GuidedDecisionTableConstants.INSTANCE.Metadata1() )
-                                  .append( GuidedDecisionTableConstants.COLON ).toString(), horiz );
-        pop.addAttribute( GuidedDecisionTableConstants.INSTANCE.Attribute(),
-                          list );
-        pop.show();
+        new GuidedDecisionTableAttributeSelectorPopup( presenter.getExistingAttributeNames().toArray( new String[0] ),
+                                                       presenter ).show();
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableAttributeSelectorPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableAttributeSelectorPopupTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
+import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
+import org.gwtbootstrap3.client.ui.Heading;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.shared.preferences.ApplicationPreferences;
+
+@WithClassesToStub({GuidedRuleEditorImages508.class, Heading.class, ApplicationPreferences.class})
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedDecisionTableAttributeSelectorPopupTest {
+
+    @Test
+    public void getAttributes() {
+        GuidedDecisionTableAttributeSelectorPopup popup = mock(GuidedDecisionTableAttributeSelectorPopup.class);
+        when(popup.getAttributes()).thenCallRealMethod();
+
+        String[] attributes = popup.getAttributes();
+        assertEquals(RuleAttributeWidget.getAttributesList().length + 1, attributes.length);
+        assertEquals(GuidedDecisionTable52.NEGATE_RULE_ATTR, attributes[attributes.length - 1]);
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleAttributeSelectorPopup.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/GuidedRuleAttributeSelectorPopup.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.client.editor;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import org.drools.workbench.models.datamodel.rule.RuleAttribute;
+import org.drools.workbench.models.datamodel.rule.RuleMetadata;
+import org.drools.workbench.models.datamodel.rule.RuleModel;
+import org.drools.workbench.screens.guided.rule.client.resources.GuidedRuleEditorResources;
+import org.gwtbootstrap3.client.ui.Button;
+import org.uberfire.ext.widgets.common.client.common.InfoPopup;
+
+public class GuidedRuleAttributeSelectorPopup extends AttributeSelectorPopup {
+
+    private final RuleModel model;
+    private final Command refresh;
+
+    public GuidedRuleAttributeSelectorPopup( final RuleModel model,
+                                             final boolean lockLHS,
+                                             final boolean lockRHS,
+                                             final Command refresh ) {
+        this.model = model;
+        this.refresh = refresh;
+
+        initialize();
+
+        setFreezePanel( lockLHS,
+                        lockRHS );
+    }
+
+    @Override
+    protected String[] getAttributes() {
+        return RuleAttributeWidget.getAttributesList();
+    }
+
+    @Override
+    protected String[] getDuplicates() {
+        int size = model.attributes.length;
+        String[] duplicates = new String[size];
+        for ( int i = 0; i < size; i++ ) {
+            duplicates[i] = model.attributes[i].getAttributeName();
+        }
+        return duplicates;
+    }
+
+    @Override
+    protected void handleAttributeAddition( final String attributeName ) {
+        if ( attributeName.equals( RuleAttributeWidget.LOCK_LHS ) || attributeName.equals( RuleAttributeWidget.LOCK_RHS ) ) {
+            model.addMetadata( new RuleMetadata( attributeName,
+                                                 "true" ) );
+        } else {
+            model.addAttribute( new RuleAttribute( attributeName,
+                                                   "" ) );
+        }
+        refresh.execute();
+    }
+
+    @Override
+    protected boolean isMetadataUnique( final String metadataName ) {
+        for ( RuleMetadata rm : model.metadataList ) {
+            if ( rm.getAttributeName().equals( metadataName ) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected String metadataNotUniqueMessage( final String metadataName ) {
+        return GuidedRuleEditorResources.CONSTANTS.MetadataNotUnique0( metadataName );
+    }
+
+    @Override
+    protected void handleMetadataAddition( final String metadataName ) {
+        model.addMetadata( new RuleMetadata( metadataName,
+                                             "" ) );
+        refresh.execute();
+    }
+
+    private void setFreezePanel( final boolean lockLHS,
+                                 final boolean lockRHS ) {
+        HorizontalPanel hz = new HorizontalPanel();
+        if ( !lockLHS ) {
+            hz.add( createFreezeButton( GuidedRuleEditorResources.CONSTANTS.Conditions(),
+                                        RuleAttributeWidget.LOCK_LHS ) );
+        }
+        if ( !lockRHS ) {
+            hz.add( createFreezeButton( GuidedRuleEditorResources.CONSTANTS.Actions(),
+                                        RuleAttributeWidget.LOCK_RHS ) );
+        }
+        hz.add( new InfoPopup( GuidedRuleEditorResources.CONSTANTS.FrozenAreas(),
+                               GuidedRuleEditorResources.CONSTANTS.FrozenExplanation() ) );
+
+        if ( hz.getWidgetCount() > 1 ) {
+            addAttribute( GuidedRuleEditorResources.CONSTANTS.FreezeAreasForEditing(),
+                          hz );
+        }
+    }
+
+    private Button createFreezeButton( final String text,
+                                       final String metadataName ) {
+        return new Button( text,
+                           (ClickEvent event) -> {
+                               model.addMetadata( new RuleMetadata( metadataName,
+                                                                    "true" ) );
+                               refresh.execute();
+                               hide();
+                           });
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleAttributeWidget.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleAttributeWidget.java
@@ -132,29 +132,25 @@ public class RuleAttributeWidget extends Composite {
     }
 
     /**
-     * Return a listbox of choices for rule attributes.
+     * Return a list of choices for rule attributes.
      * @return
      */
-    public static ListBox getAttributeList() {
-        ListBox list = new ListBox();
-        list.addItem( GuidedRuleEditorResources.CONSTANTS.Choose() );
-
-        list.addItem( SALIENCE_ATTR );
-        list.addItem( ENABLED_ATTR );
-        list.addItem( DATE_EFFECTIVE_ATTR );
-        list.addItem( DATE_EXPIRES_ATTR );
-        list.addItem( NO_LOOP_ATTR );
-        list.addItem( AGENDA_GROUP_ATTR );
-        list.addItem( ACTIVATION_GROUP_ATTR );
-        list.addItem( DURATION_ATTR );
-        list.addItem( TIMER_ATTR );
-        list.addItem( CALENDARS_ATTR );
-        list.addItem( AUTO_FOCUS_ATTR );
-        list.addItem( LOCK_ON_ACTIVE_ATTR );
-        list.addItem( RULEFLOW_GROUP_ATTR );
-        list.addItem( DIALECT_ATTR );
-
-        return list;
+    public static String[] getAttributesList() {
+        return new String[] { GuidedRuleEditorResources.CONSTANTS.Choose(),
+                              SALIENCE_ATTR,
+                              ENABLED_ATTR,
+                              DATE_EFFECTIVE_ATTR,
+                              DATE_EXPIRES_ATTR,
+                              NO_LOOP_ATTR,
+                              AGENDA_GROUP_ATTR,
+                              ACTIVATION_GROUP_ATTR,
+                              DURATION_ATTR,
+                              TIMER_ATTR,
+                              CALENDARS_ATTR,
+                              AUTO_FOCUS_ATTR,
+                              LOCK_ON_ACTIVE_ATTR,
+                              RULEFLOW_GROUP_ATTR,
+                              DIALECT_ATTR };
     }
 
     private Widget getEditorWidget( final RuleAttribute at,

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/RuleModeller.java
@@ -352,17 +352,14 @@ public class RuleModeller extends Composite
     }
 
     protected void showAttributeSelector() {
-        AttributeSelectorPopup pop = new AttributeSelectorPopup( model,
-                                                                 lockLHS(),
-                                                                 lockRHS(),
-                                                                 new Command() {
-
-                                                                     public void execute() {
-                                                                         refreshWidget();
-                                                                     }
-                                                                 } );
-
-        pop.show();
+        new GuidedRuleAttributeSelectorPopup( model,
+                                              lockLHS(),
+                                              lockRHS(),
+                                              new Command() {
+                                                  public void execute() {
+                                                      refreshWidget();
+                                                  }
+                                              } ).show();
     }
 
     /**

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/resources/images/GuidedRuleEditorImages508.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/resources/images/GuidedRuleEditorImages508.java
@@ -76,4 +76,9 @@ public class GuidedRuleEditorImages508 {
         return image;
     }
 
+    public Image Configure() {
+        Image image = new Image( GuidedRuleEditorResources.INSTANCE.images().config() );
+        image.setAltText( GuidedRuleEditorResources.CONSTANTS.Config() );
+        return image;
+    }
 }

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopupTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.rule.client.editor;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gwt.user.client.Element;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.screens.guided.rule.client.resources.images.GuidedRuleEditorImages508;
+import org.gwtbootstrap3.client.ui.Heading;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+@WithClassesToStub({GuidedRuleEditorImages508.class, Heading.class})
+@RunWith(GwtMockitoTestRunner.class)
+public class AttributeSelectorPopupTest {
+
+    static String[] attributes = new String[] {"attr1", "attr2", "attr3", "attr4"};
+    static String[] duplicates = new String[] {"attr2", "attr3"};
+    static String metadataName = "mockMetadata";
+
+    @GwtMock
+    TextBox boxMock;
+    @GwtMock
+    ListBox listMock;
+
+    List<String> listMockAttributes;
+
+    MockAttributeSelectorPopup popup;
+
+    @Before
+    public void setUp() {
+        listMockAttributes = new ArrayList<>();
+        popup = spy(new MockAttributeSelectorPopup());
+        when(boxMock.getElement()).thenReturn(mock(Element.class));
+        when(boxMock.getText()).thenReturn(metadataName);
+        when(listMock.getItemCount()).thenAnswer(
+            (InvocationOnMock invocation) -> listMockAttributes.size()
+        );
+        when(listMock.getItemText(anyInt())).thenAnswer(
+            (InvocationOnMock invocation) -> listMockAttributes.get((int) invocation.getArguments()[0])
+        );
+        doAnswer((Answer<Void>)
+            (InvocationOnMock invocation) -> {
+                listMockAttributes.add((String) invocation.getArguments()[0]);
+                return null;
+            }
+        ).when(listMock).addItem(anyString());
+        doAnswer((Answer<Void>)
+            (InvocationOnMock invocation) -> {
+                listMockAttributes.remove((int) invocation.getArguments()[0]);
+                return null;
+            }
+        ).when(listMock).removeItem(anyInt());
+        popup.initialize(boxMock, listMock);
+    }
+
+    @Test
+    public void alreadyUsedAttributesRemoved() {
+        verify(popup).getAttributes();
+        verify(popup).getDuplicates();
+        verify(popup.list, times(4)).addItem(anyString());
+        verify(popup.list, times(2)).removeItem(1);
+    }
+
+    @Test
+    public void alreadyUsedMetadataNotAllowed() {
+        popup.getMetadataHandler().onClick(null);
+        verify(popup).isMetadataUnique(metadataName);
+        verify(popup).metadataNotUniqueMessage(metadataName);
+        verify(popup, never()).handleMetadataAddition(anyString());
+    }
+
+    @Test
+    public void emptyMetadataNotAllowed() {
+        when(boxMock.getText()).thenReturn("");
+        popup.getMetadataHandler().onClick(null);
+        verify(popup, never()).handleMetadataAddition(anyString());
+    }
+
+    @Test
+    public void whitespaceMetadataNotAllowed() {
+        when(boxMock.getText()).thenReturn(" \n\t ");
+        popup.getMetadataHandler().onClick(null);
+        verify(popup, never()).handleMetadataAddition(anyString());
+    }
+
+    private static class MockAttributeSelectorPopup extends AttributeSelectorPopup {
+
+        @Override
+        protected String[] getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        protected String[] getDuplicates() {
+            return duplicates;
+        }
+
+        @Override
+        protected void handleAttributeAddition(String attributeName) {
+            // mock, do nothing
+        }
+
+        @Override
+        protected boolean isMetadataUnique(String metadataName) {
+            return false;
+        }
+
+        @Override
+        protected String metadataNotUniqueMessage(String metadataName) {
+            return "mock message";
+        }
+
+        @Override
+        protected void handleMetadataAddition(String metadataName) {
+            // mock, do nothing
+        }
+    }
+}


### PR DESCRIPTION
The original AttributeSelectorPopup code was almost 1:1 copied to GuidedDecisionTableViewImpl. This removes the duplication - the AttributeSelectorPopup is now an abstract parent of 2 separate implementations. Shared code (most logic) stayed there.

This also brings the basic metadata input validation that was present in GRE to GDT.

There are now also a few small tests checking that validation and that duplicates are not allowed (part of moving selenium tests to community).