### PR TITLE
add tests for GDT audit log

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/auditlog/AuditLogEntryCellHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/auditlog/AuditLogEntryCellHelper.java
@@ -480,12 +480,12 @@ public class AuditLogEntryCellHelper {
                                                  diff.getOldValue(),
                                                  diff.getValue(),
                                                  sbFields );
-                    } else if ( changedFieldName.equals( AttributeCol52.FIELD_HIDE_COLUMN ) ) {
+                    } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_HIDE_COLUMN ) ) {
                         buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.HideThisColumn(),
                                                  diff.getOldValue(),
                                                  diff.getValue(),
                                                  sbFields );
-                    } else if ( changedFieldName.equals( AttributeCol52.FIELD_DEFAULT_VALUE ) ) {
+                    } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_DEFAULT_VALUE ) ) {
                         buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.DefaultValue(),
                                                  diff.getOldValue(),
                                                  diff.getValue(),
@@ -520,12 +520,12 @@ public class AuditLogEntryCellHelper {
             sbFields = new SafeHtmlBuilder();
             for ( BaseColumnFieldDiff diff : diffs ) {
                 String changedFieldName = diff.getFieldName();
-                if ( changedFieldName.equals( AttributeCol52.FIELD_HIDE_COLUMN ) ) {
+                if ( changedFieldName.equals( DTColumnConfig52.FIELD_HIDE_COLUMN ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.HideThisColumn(),
                                              diff.getOldValue(),
                                              diff.getValue(),
                                              sbFields );
-                } else if ( changedFieldName.equals( AttributeCol52.FIELD_DEFAULT_VALUE ) ) {
+                } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_DEFAULT_VALUE ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.DefaultValue(),
                                              diff.getOldValue(),
                                              diff.getValue(),
@@ -706,7 +706,7 @@ public class AuditLogEntryCellHelper {
 
     }
 
-    private String getLiteralForCalculationType( final Integer type ) {
+    String getLiteralForCalculationType( final Integer type ) {
         switch ( type ) {
             case BaseSingleFieldConstraint.TYPE_LITERAL:
                 return GuidedDecisionTableConstants.INSTANCE.LiteralValue();
@@ -984,7 +984,7 @@ public class AuditLogEntryCellHelper {
             sbFields = new SafeHtmlBuilder();
             for ( BaseColumnFieldDiff diff : diffs ) {
                 String changedFieldName = diff.getFieldName();
-                if ( changedFieldName.equals( MetadataCol52.FIELD_DEFAULT_VALUE ) ) {
+                if ( changedFieldName.equals( DTColumnConfig52.FIELD_DEFAULT_VALUE ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.DefaultValue(),
                                              diff.getOldValue(),
                                              diff.getValue(),
@@ -994,12 +994,12 @@ public class AuditLogEntryCellHelper {
                                              diff.getOldValue(),
                                              diff.getValue(),
                                              sbFields );
-                } else if ( changedFieldName.equals( MetadataCol52.FIELD_HEADER ) ) {
+                } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_HEADER ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.ColumnHeader(),
                                              diff.getOldValue(),
                                              diff.getValue(),
                                              sbFields );
-                } else if ( changedFieldName.equals( MetadataCol52.FIELD_HIDE_COLUMN ) ) {
+                } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_HIDE_COLUMN ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.HideThisColumn(),
                                              diff.getOldValue(),
                                              diff.getValue(),
@@ -1081,12 +1081,12 @@ public class AuditLogEntryCellHelper {
             sbFields = new SafeHtmlBuilder();
             for ( BaseColumnFieldDiff diff : diffs ) {
                 String changedFieldName = diff.getFieldName();
-                if ( changedFieldName.equals( MetadataCol52.FIELD_HEADER ) ) {
+                if ( changedFieldName.equals( DTColumnConfig52.FIELD_HEADER ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.ColumnHeader(),
                                              diff.getOldValue(),
                                              diff.getValue(),
                                              sbFields );
-                } else if ( changedFieldName.equals( MetadataCol52.FIELD_HIDE_COLUMN ) ) {
+                } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_HIDE_COLUMN ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.HideThisColumn(),
                                              diff.getOldValue(),
                                              diff.getValue(),
@@ -1148,12 +1148,12 @@ public class AuditLogEntryCellHelper {
             sbFields = new SafeHtmlBuilder();
             for ( BaseColumnFieldDiff diff : diffs ) {
                 String changedFieldName = diff.getFieldName();
-                if ( changedFieldName.equals( MetadataCol52.FIELD_HEADER ) ) {
+                if ( changedFieldName.equals( DTColumnConfig52.FIELD_HEADER ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.ColumnHeader(),
                                              diff.getOldValue(),
                                              diff.getValue(),
                                              sbFields );
-                } else if ( changedFieldName.equals( MetadataCol52.FIELD_HIDE_COLUMN ) ) {
+                } else if ( changedFieldName.equals( DTColumnConfig52.FIELD_HIDE_COLUMN ) ) {
                     buildColumnUpdateFields( GuidedDecisionTableConstants.INSTANCE.HideThisColumn(),
                                              diff.getOldValue(),
                                              diff.getValue(),
@@ -1233,37 +1233,14 @@ public class AuditLogEntryCellHelper {
         return displayText == null ? "" : displayText;
     }
 
-    private String convertValueToString( final Object o ) {
-        if ( o instanceof Boolean ) {
-            Boolean booleanValue = (Boolean) o;
-            return ( booleanValue == null ? null : booleanValue.toString() );
-        } else if ( o instanceof Date ) {
-            Date dateValue = (Date) o;
-            return ( dateValue == null ? null : format.format( dateValue ) );
+    String convertValueToString( final Object o ) {
+        if (o == null) {
+            return null;
+        }
+        if ( o instanceof Date ) {
+            return format.format( (Date) o );
         } else if ( o instanceof BigDecimal ) {
-            BigDecimal bigDecimalValue = (BigDecimal) o;
-            return ( bigDecimalValue == null ? null : bigDecimalValue.toPlainString() );
-        } else if ( o instanceof BigInteger ) {
-            BigInteger bigIntegerValue = (BigInteger) o;
-            return ( bigIntegerValue == null ? null : bigIntegerValue.toString() );
-        } else if ( o instanceof Byte ) {
-            Byte byteValue = (Byte) o;
-            return ( byteValue == null ? null : byteValue.toString() );
-        } else if ( o instanceof Double ) {
-            Double doubleValue = (Double) o;
-            return ( doubleValue == null ? null : doubleValue.toString() );
-        } else if ( o instanceof Float ) {
-            Float floatValue = (Float) o;
-            return ( floatValue == null ? null : floatValue.toString() );
-        } else if ( o instanceof Integer ) {
-            Integer integerValue = (Integer) o;
-            return ( integerValue == null ? null : integerValue.toString() );
-        } else if ( o instanceof Long ) {
-            Long longValue = (Long) o;
-            return ( longValue == null ? null : longValue.toString() );
-        } else if ( o instanceof Short ) {
-            Short shortValue = (Short) o;
-            return ( shortValue == null ? null : shortValue.toString() );
+            return ( (BigDecimal) o ).toPlainString();
         } else {
             return o.toString();
         }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/auditlog/AuditLogEntryCellHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/auditlog/AuditLogEntryCellHelperTest.java
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.auditlog;
+
+import static java.lang.String.format;
+import static org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52.FIELD_CONSTRAINT_VALUE_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.safehtml.shared.SafeHtml;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.datamodel.rule.ActionRetractFact;
+import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.datamodel.rule.FactPattern;
+import org.drools.workbench.models.datamodel.workitems.PortableStringParameterDefinition;
+import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
+import org.drools.workbench.models.guided.dtable.shared.auditlog.UpdateColumnAuditLogEntry;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BRLActionColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTColumnConfig52;
+import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryActionSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.models.guided.dtable.shared.model.WorkItemColumnParameterValueDiffImpl;
+import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class AuditLogEntryCellHelperTest {
+
+    @Mock
+    private DateTimeFormat format;
+    private String labelClass = "mockCssClassForLabel";
+    private AuditLogEntryCellHelper helper;
+
+    @Before
+    public void setUp() throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+        when(format.format(any(Date.class))).thenReturn("mockDateString");
+        // This also mock AuditLogEntryCellHelper.Template, which then for each method call returns "<method name>(<call arguments>)
+        // instead of the "templated" String. Calling SafeHtml.asString() then gives us something like:
+        // commentHeader(<new header>)updatedFields(updatedField(<field description>, <old value>, <new value>)...)
+        // From that we can assert that all diffs were properly used and displayed.
+        helper = new AuditLogEntryCellHelper(format, labelClass, "mockCssClassForValue");
+    }
+
+    @Test
+    public void convertValueToString() {
+        assertEquals(null, helper.convertValueToString(null));
+        assertEquals("true", helper.convertValueToString(true));
+        assertEquals("false", helper.convertValueToString(false));
+        Date date = new Date();
+        assertEquals(format.format(date), helper.convertValueToString(date));
+        assertEquals(BigDecimal.ONE.toPlainString(), helper.convertValueToString(BigDecimal.ONE));
+        assertEquals(BigInteger.ONE.toString(), helper.convertValueToString(BigInteger.ONE));
+        Byte b = Byte.MAX_VALUE;
+        assertEquals(b.toString(), helper.convertValueToString(b));
+        Double d = 123.456;
+        assertEquals(d.toString(), helper.convertValueToString(d));
+        Float f = new Float(123.456);
+        assertEquals(f.toString(), helper.convertValueToString(f));
+        Integer i = 123;
+        assertEquals(i.toString(), helper.convertValueToString(i));
+        Long l = new Long(123);
+        assertEquals(l.toString(), helper.convertValueToString(l));
+        Short s = 123;
+        assertEquals(s.toString(), helper.convertValueToString(s));
+        assertEquals("surprise!", helper.convertValueToString("surprise!"));
+    }
+
+    @Test
+    public void getSafeHtml_Metadata() {
+        MetadataCol52 originalColumn = new MetadataCol52();
+        originalColumn.setHideColumn(true);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+        // header & metadata of a metadata column cannot be updated in the ui
+        originalColumn.setMetadata("meta");
+        originalColumn.setHeader("meta");
+
+        MetadataCol52 newColumn = new MetadataCol52();
+        newColumn.setHideColumn(false);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+        // header & metadata of a metadata column cannot be updated in the ui
+        newColumn.setMetadata("meta");
+        newColumn.setHeader("meta");
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_Attribute() {
+        AttributeCol52 originalColumn = new AttributeCol52();
+        originalColumn.setReverseOrder(false);
+        originalColumn.setUseRowNumber(false);
+        originalColumn.setHideColumn(false);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+        // header & attribute name of an attribute column cannot be updated in the ui
+        originalColumn.setAttribute("attr");
+        originalColumn.setHeader("attr");
+
+        AttributeCol52 newColumn = new AttributeCol52();
+        newColumn.setReverseOrder(true);
+        newColumn.setUseRowNumber(true);
+        newColumn.setHideColumn(true);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+        // header & attribute name of an attribute column cannot be updated in the ui
+        newColumn.setAttribute("attr");
+        newColumn.setHeader("attr");
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getAttributeHeaderRepre(newColumn.getAttribute()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_Condition() {
+        ConditionCol52 originalColumn = new ConditionCol52();
+        originalColumn.setBinding("bind1");
+        originalColumn.setConstraintValueType(BaseSingleFieldConstraint.TYPE_LITERAL);
+        originalColumn.setFactField("field1");
+        originalColumn.setFieldType("FieldType1");
+        originalColumn.setOperator("==");
+        originalColumn.setValueList("a,b,c");
+        originalColumn.setHeader("condition1");
+        originalColumn.setHideColumn(false);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+
+        ConditionCol52 newColumn = new ConditionCol52();
+        newColumn.setBinding("bind2");
+        newColumn.setConstraintValueType(BaseSingleFieldConstraint.TYPE_PREDICATE);
+        newColumn.setFactField("field2");
+        newColumn.setFieldType("FieldType2");
+        newColumn.setOperator("!=");
+        newColumn.setValueList("x,y,z");
+        newColumn.setHeader("condition2");
+        newColumn.setHideColumn(true);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+
+        Pattern52 originalPattern = new Pattern52();
+        originalPattern.setBoundName("patBind1");
+        originalPattern.setFactType("FactType1");
+        originalPattern.setEntryPointName("ep1");
+
+        Pattern52 newPattern = new Pattern52();
+        newPattern.setBoundName("patBind2");
+        newPattern.setFactType("FactType2");
+        newPattern.setEntryPointName("ep2");
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+        diffs.addAll(originalPattern.diff(newPattern));
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getConditionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionInsert() {
+        //hide, insert, value list, default value, field, header
+        ActionInsertFactCol52 originalColumn = new ActionInsertFactCol52();
+        originalColumn.setFactField("field1");
+        originalColumn.setInsertLogical(false);
+        originalColumn.setValueList("q,w,e");
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+
+        ActionInsertFactCol52 newColumn = new ActionInsertFactCol52();
+        newColumn.setFactField("field2");
+        newColumn.setInsertLogical(true);
+        newColumn.setValueList("a,s,d");
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionSetField() {
+        ActionSetFieldCol52 originalColumn = new ActionSetFieldCol52();
+        originalColumn.setBoundName("bind1");
+        originalColumn.setFactField("field1");
+        originalColumn.setUpdate(false);
+        originalColumn.setValueList("q,w,e");
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+
+        ActionSetFieldCol52 newColumn = new ActionSetFieldCol52();
+        newColumn.setBoundName("bind2");
+        newColumn.setFactField("field2");
+        newColumn.setUpdate(true);
+        newColumn.setValueList("a,s,d");
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionRetract() {
+        ActionRetractFactCol52 originalColumn = new ActionRetractFactCol52();
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+        originalColumn.setDefaultValue(new DTCellValue52("def1"));
+
+        ActionRetractFactCol52 newColumn = new ActionRetractFactCol52();
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+        newColumn.setDefaultValue(new DTCellValue52("def2"));
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionWorkItemExecute_Simple() {
+        ActionWorkItemCol52 originalColumn = new ActionWorkItemCol52();
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+
+        ActionWorkItemCol52 newColumn = new ActionWorkItemCol52();
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+
+        PortableStringParameterDefinition param1 = new PortableStringParameterDefinition();
+        param1.setName("param1");
+        param1.setValue("value1");
+
+        PortableWorkDefinition def1 = new PortableWorkDefinition();
+        def1.setName("def1name");
+        def1.addParameter(param1);
+
+        PortableStringParameterDefinition param3 = new PortableStringParameterDefinition();
+        param3.setName("param3");
+        param3.setValue("value3");
+
+        PortableWorkDefinition def2 = new PortableWorkDefinition();
+        def2.setName("def2name");
+        def2.addParameter(param3);
+
+        originalColumn.setWorkItemDefinition(def1);
+        newColumn.setWorkItemDefinition(def2);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionWorkItemExecute_Complex() {
+        ActionWorkItemCol52 originalColumn = new ActionWorkItemCol52();
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+
+        ActionWorkItemCol52 newColumn = new ActionWorkItemCol52();
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+
+        PortableStringParameterDefinition param1 = new PortableStringParameterDefinition();
+        param1.setName("param1");
+        param1.setValue("value1");
+
+        PortableStringParameterDefinition param2 = new PortableStringParameterDefinition();
+        param2.setName("param2");
+        param2.setValue("value2");
+
+        PortableWorkDefinition def1 = new PortableWorkDefinition();
+        def1.setName("def1name");
+        def1.addParameter(param1);
+        def1.addParameter(param2);
+
+        PortableStringParameterDefinition param3 = new PortableStringParameterDefinition();
+        param3.setName("param3");
+        param3.setValue("value3");
+
+        PortableStringParameterDefinition param4 = new PortableStringParameterDefinition();
+        param4.setName("param1");
+        param4.setValue("value1");
+
+        PortableStringParameterDefinition param5 = new PortableStringParameterDefinition();
+        param5.setName("param5");
+        param5.setBinding("binding5");
+
+        PortableStringParameterDefinition param6 = new PortableStringParameterDefinition();
+        param6.setName("param2");
+        param6.setValue("value6");
+
+        PortableWorkDefinition def2 = new PortableWorkDefinition();
+        def2.setName("def2name");
+        def2.addParameter(param3);
+        def2.addParameter(param4);
+        def2.addParameter(param5);
+        def2.addParameter(param6);
+
+        originalColumn.setWorkItemDefinition(def1);
+        newColumn.setWorkItemDefinition(def2);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionWorkItemInsert() {
+        ActionWorkItemInsertFactCol52 originalColumn = new ActionWorkItemInsertFactCol52();
+        originalColumn.setParameterClassName("ParamClass1");
+        originalColumn.setWorkItemName("WI1");
+        originalColumn.setWorkItemResultParameterName("param1");
+        originalColumn.setBoundName("b1");
+        originalColumn.setFactField("field1");
+        originalColumn.setInsertLogical(false);
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+
+        ActionWorkItemInsertFactCol52 newColumn = new ActionWorkItemInsertFactCol52();
+        newColumn.setParameterClassName("ParamClass2");
+        newColumn.setWorkItemName("WI2");
+        newColumn.setWorkItemResultParameterName("param2");
+        newColumn.setBoundName("b2");
+        newColumn.setFactField("field2");
+        newColumn.setInsertLogical(true);
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_ActionWorkItemSetField() {
+        ActionWorkItemSetFieldCol52 originalColumn = new ActionWorkItemSetFieldCol52();
+        originalColumn.setParameterClassName("ParamClass1");
+        originalColumn.setWorkItemName("WI1");
+        originalColumn.setWorkItemResultParameterName("param1");
+        originalColumn.setBoundName("bind1");
+        originalColumn.setFactField("field1");
+        originalColumn.setUpdate(false);
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+
+        ActionWorkItemSetFieldCol52 newColumn = new ActionWorkItemSetFieldCol52();
+        newColumn.setParameterClassName("ParamClass2");
+        newColumn.setWorkItemName("WI2");
+        newColumn.setWorkItemResultParameterName("param2");
+        newColumn.setBoundName("bind2");
+        newColumn.setFactField("field2");
+        newColumn.setUpdate(true);
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getActionHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_BrlCondition() {
+        // Definition diffs are currently not supported, maybe #soon?
+        BRLConditionColumn originalColumn = new BRLConditionColumn();
+//        originalColumn.setDefinition(Arrays.asList(new FactPattern("FactType1")));
+        originalColumn.setHeader("condition1");
+        originalColumn.setHideColumn(false);
+
+        BRLConditionColumn newColumn = new BRLConditionColumn();
+//        originalColumn.setDefinition(Arrays.asList(new FactPattern("FactType2"), new FactPattern("FactType3")));
+        newColumn.setHeader("condition2");
+        newColumn.setHideColumn(true);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_BrlCondition_DefinitionOnly() {
+        BRLConditionColumn originalColumn = new BRLConditionColumn();
+        originalColumn.setDefinition(Arrays.asList(new FactPattern("FactType1")));
+        originalColumn.setHeader("condition");
+        originalColumn.setHideColumn(false);
+
+        BRLConditionColumn newColumn = new BRLConditionColumn();
+        originalColumn.setDefinition(Arrays.asList(new FactPattern("FactType2"), new FactPattern("FactType3")));
+        newColumn.setHeader("condition");
+        newColumn.setHideColumn(false);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        // Definition diffs are currently not supported, maybe #soon?
+//        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(new ArrayList<>()), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_BrlAction() {
+        // Definition diffs are currently not supported, maybe #soon?
+        BRLActionColumn originalColumn = new BRLActionColumn();
+//        originalColumn.setDefinition(Arrays.asList(new ActionRetractFact("fact1")));
+        originalColumn.setHeader("action1");
+        originalColumn.setHideColumn(false);
+
+        BRLActionColumn newColumn = new BRLActionColumn();
+//        newColumn.setDefinition(Arrays.asList(new ActionRetractFact("fact2"), new ActionRetractFact("fact3")));
+        newColumn.setHeader("action2");
+        newColumn.setHideColumn(true);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+    }
+
+    @Test
+    public void getSafeHtml_BrlAction_DefinitionOnly() {
+        BRLActionColumn originalColumn = new BRLActionColumn();
+        originalColumn.setDefinition(Arrays.asList(new ActionRetractFact("fact1")));
+        originalColumn.setHeader("action");
+        originalColumn.setHideColumn(false);
+
+        BRLActionColumn newColumn = new BRLActionColumn();
+        newColumn.setDefinition(Arrays.asList(new ActionRetractFact("fact2"), new ActionRetractFact("fact3")));
+        newColumn.setHeader("action");
+        newColumn.setHideColumn(false);
+
+        List<BaseColumnFieldDiff> diffs = originalColumn.diff(newColumn);
+
+        SafeHtml result = helper.getSafeHtml(new UpdateColumnAuditLogEntry("mock user", originalColumn, newColumn, diffs));
+
+        // Definition diffs are currently not supported, maybe #soon?
+//        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(diffs), result.asString());
+        assertEquals(getHeaderRepre(newColumn.getHeader()) + getDiffRepre(new ArrayList<>()), result.asString());
+    }
+
+    private String getHeaderRepre(String header) {
+        return format("commentHeader(DecisionTableAuditLogUpdateColumn(%s))", header);
+    }
+
+    private String getAttributeHeaderRepre(String header) {
+        return format("commentHeader(DecisionTableAuditLogUpdateAttribute(%s))", header);
+    }
+
+    private String getConditionHeaderRepre(String header) {
+        return format("commentHeader(DecisionTableAuditLogUpdateCondition(%s))", header);
+    }
+
+    private String getActionHeaderRepre(String header) {
+        return format("commentHeader(DecisionTableAuditLogUpdateAction(%s))", header);
+    }
+
+    private String getDiffRepre(List<BaseColumnFieldDiff> diffs) {
+        String diffsRepre = "";
+        for (BaseColumnFieldDiff diff : diffs) {
+            diffsRepre += getDiffRepre(diff);
+        }
+        return format("updatedFields(%s, %s)", diffsRepre, labelClass);
+    }
+
+    private String getDiffRepre(BaseColumnFieldDiff diff) {
+        boolean constraintValueType = diff.getFieldName().equals(FIELD_CONSTRAINT_VALUE_TYPE);
+        boolean WIParamValueOnly = diff instanceof WorkItemColumnParameterValueDiffImpl;
+        String paramName = WIParamValueOnly ? ((WorkItemColumnParameterValueDiffImpl) diff).getParameterName() : "";
+        return format("updatedField(%s, '%s', '%s')",
+            getDisplayableFieldValue(diff.getFieldName(), paramName, WIParamValueOnly), getNonNullValue(diff.getOldValue(), constraintValueType), getNonNullValue(diff.getValue(), constraintValueType));
+    }
+
+    private String getNonNullValue(Object diffValue, boolean constraintValueType) {
+        String value = "";
+        if (diffValue != null) {
+            if (constraintValueType) {
+                value = helper.getLiteralForCalculationType((Integer) diffValue);
+            } else {
+                value = diffValue.toString();
+            }
+        }
+        return value;
+    }
+
+    // this might be useful in the helper itself..?
+    private String getDisplayableFieldValue( String field, String optionalParameter, boolean WIParamValueOnly ) {
+        switch ( field ) {
+            case DTColumnConfig52.FIELD_HEADER: return GuidedDecisionTableConstants.INSTANCE.ColumnHeader();
+            case DTColumnConfig52.FIELD_HIDE_COLUMN : return GuidedDecisionTableConstants.INSTANCE.HideThisColumn();
+            case DTColumnConfig52.FIELD_DEFAULT_VALUE : return GuidedDecisionTableConstants.INSTANCE.DefaultValue();
+            case MetadataCol52.FIELD_METADATA : return GuidedDecisionTableConstants.INSTANCE.Metadata1();
+            case AttributeCol52.FIELD_REVERSE_ORDER : return GuidedDecisionTableConstants.INSTANCE.ReverseOrder();
+            case AttributeCol52.FIELD_USE_ROW_NUMBER : return GuidedDecisionTableConstants.INSTANCE.UseRowNumber();
+            case Pattern52.FIELD_ENTRY_POINT_NAME : return GuidedDecisionTableConstants.INSTANCE.DTLabelFromEntryPoint();
+            case ConditionCol52.FIELD_BINDING : return GuidedDecisionTableConstants.INSTANCE.Binding();
+            case ConditionCol52.FIELD_CONSTRAINT_VALUE_TYPE : return GuidedDecisionTableConstants.INSTANCE.CalculationType();
+            case ConditionCol52.FIELD_OPERATOR : return GuidedDecisionTableConstants.INSTANCE.Operator();
+            case ConditionCol52.FIELD_FIELD_TYPE :
+            case ActionSetFieldCol52.FIELD_TYPE : return GuidedDecisionTableConstants.INSTANCE.FieldType();
+            case ActionSetFieldCol52.FIELD_UPDATE : return GuidedDecisionTableConstants.INSTANCE.UpdateEngineWithChanges();
+            case ActionInsertFactCol52.FIELD_IS_INSERT_LOGICAL : return GuidedDecisionTableConstants.INSTANCE.LogicallyInsert();
+            case ActionWorkItemCol52.FIELD_WORKITEM_DEFINITION_NAME : return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemName();
+            case ActionWorkItemCol52.FIELD_WORKITEM_DEFINITION_PARAMETER_NAME : return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemParameterName();
+            case ActionWorkItemCol52.FIELD_WORKITEM_DEFINITION_PARAMETER_VALUE : {
+                if ( WIParamValueOnly ) {
+                    return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemParameterValueOnly0( optionalParameter );
+                } else {
+                    return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemParameterValue();
+                }
+            }
+        }
+        if ( Arrays.asList( Pattern52.FIELD_FACT_TYPE,
+                            ActionInsertFactCol52.FIELD_FACT_TYPE ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.FactType();
+        }
+        if ( Arrays.asList( Pattern52.FIELD_BOUND_NAME,
+                            ActionInsertFactCol52.FIELD_BOUND_NAME,
+                            ActionSetFieldCol52.FIELD_BOUND_NAME ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.Binding();
+        }
+        if ( Arrays.asList( ConditionCol52.FIELD_FACT_FIELD,
+                            ActionInsertFactCol52.FIELD_FACT_FIELD,
+                             ActionSetFieldCol52.FIELD_FACT_FIELD ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.Field();
+        }
+        if ( Arrays.asList( ConditionCol52.FIELD_VALUE_LIST,
+                            ActionInsertFactCol52.FIELD_VALUE_LIST,
+                            ActionSetFieldCol52.FIELD_VALUE_LIST ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.ValueList();
+        }
+        if ( Arrays.asList( ActionWorkItemInsertFactCol52.FIELD_PARAMETER_CLASSNAME,
+                            ActionWorkItemSetFieldCol52.FIELD_PARAMETER_CLASSNAME ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemParameterClassName();
+        }
+        if ( Arrays.asList( ActionWorkItemInsertFactCol52.FIELD_WORK_ITEM_NAME,
+                            ActionWorkItemSetFieldCol52.FIELD_WORK_ITEM_NAME ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemName();
+        }
+        if ( Arrays.asList( ActionWorkItemInsertFactCol52.FIELD_WORK_ITEM_RESULT_PARAM_NAME,
+                            ActionWorkItemSetFieldCol52.FIELD_WORK_ITEM_RESULT_PARAM_NAME ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.DecisionTableAuditLogWorkItemParameterName();
+        }
+        if ( Arrays.asList( LimitedEntryActionInsertFactCol52.FIELD_VALUE,
+                            LimitedEntryActionSetFieldCol52.FIELD_VALUE,
+                            LimitedEntryConditionCol52.FIELD_VALUE ).contains( field ) ) {
+            return GuidedDecisionTableConstants.INSTANCE.Value();
+        }
+        return "";
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter_AuditLogTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import com.ait.lienzo.client.core.shape.Layer;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.drools.workbench.models.datamodel.workitems.PortableWorkDefinition;
+import org.drools.workbench.models.guided.dtable.shared.auditlog.UpdateColumnAuditLogEntry;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshActionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.lockmanager.GuidedDecisionTableLockManager;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.impl.GridWidgetColumnFactoryImpl;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer.MoveColumnVetoException;
+import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
+import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.mocks.EventSourceMock;
+
+@WithClassesToStub({Text.class, DateTimeFormat.class})
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedDecisionTablePresenter_AuditLogTest {
+
+    @Mock
+    private User identity;
+    @Mock
+    private AsyncPackageDataModelOracleFactory oracleFactory;
+    @Mock
+    private ModelSynchronizer synchronizer;
+    @Mock
+    private SyncBeanManager beanManager;
+    @Mock
+    private GuidedDecisionTableModellerPresenter modellerPresenter;
+    @Mock
+    private GuidedDecisionTableLockManager lockManager;
+    @Mock
+    private GuidedDecisionTableView view;
+    @Mock
+    private EventSourceMock<RefreshAttributesPanelEvent> refreshAttributesPanelEvent;
+    @Mock
+    private EventSourceMock<RefreshMetaDataPanelEvent> refreshMetaDataPanelEvent;
+    @Mock
+    private EventSourceMock<RefreshConditionsPanelEvent> refreshConditionsPanelEvent;
+    @Mock
+    private EventSourceMock<RefreshActionsPanelEvent> refreshActionsPanelEvent;
+
+    private GridWidgetColumnFactory gridWidgetColumnFactory = new GridWidgetColumnFactoryImpl();
+    private GuidedDecisionTablePresenter dtPresenter;
+    private GuidedDecisionTableEditorContent dtContent;
+    private GuidedDecisionTable52 model = spy(new GuidedDecisionTable52());
+
+    private List<BaseColumnFieldDiff> diffs;
+
+    @Before
+    public void setup() throws MoveColumnVetoException {
+        setupPresenter();
+
+        for (Entry<String, Boolean> entry : model.getAuditLog().getAuditLogFilter().getAcceptedTypes().entrySet()) {
+            entry.setValue(Boolean.TRUE);
+        }
+        Mockito.reset(model);
+
+        diffs = new ArrayList();
+        diffs.add(null);
+        when(synchronizer.updateColumn(any(BaseColumn.class), any(BaseColumn.class))).thenReturn(diffs);
+        when(synchronizer.updateColumn(any(Pattern52.class), any(ConditionCol52.class), any(Pattern52.class), any(ConditionCol52.class))).thenReturn(diffs);
+    }
+
+    private void setupPresenter() {
+        dtPresenter = new GuidedDecisionTablePresenter( identity,
+                                                        null,
+                                                        null,
+                                                        null,
+                                                        null,
+                                                        null,
+                                                        null,
+                                                        refreshAttributesPanelEvent,
+                                                        refreshMetaDataPanelEvent,
+                                                        refreshConditionsPanelEvent,
+                                                        refreshActionsPanelEvent,
+                                                        null,
+                                                        null,
+                                                        gridWidgetColumnFactory,
+                                                        oracleFactory,
+                                                        synchronizer,
+                                                        beanManager,
+                                                        lockManager,
+                                                        null,
+                                                        null ) {
+            @Override
+            void initialiseLockManager() {
+                //Do nothing for tests
+            }
+
+            @Override
+            GuidedDecisionTableView makeView( final Set<PortableWorkDefinition> workItemDefinitions ) {
+                return view;
+            }
+
+            @Override
+            void initialiseModels() {
+                //Do nothing for tests
+            }
+        };
+
+        final AsyncPackageDataModelOracle dmo = mock( AsyncPackageDataModelOracle.class );
+        final PackageDataModelOracleBaselinePayload dmoBaseline = mock( PackageDataModelOracleBaselinePayload.class );
+        final Set<PortableWorkDefinition> workItemDefinitions = Collections.emptySet();
+        final Overview overview = mock( Overview.class );
+
+        dtContent = new GuidedDecisionTableEditorContent( model,
+                                                          workItemDefinitions,
+                                                          overview,
+                                                          dmoBaseline );
+
+        when( oracleFactory.makeAsyncPackageDataModelOracle( any( Path.class ),
+                                                             any( GuidedDecisionTable52.class ),
+                                                             eq( dmoBaseline ) ) ).thenReturn( dmo );
+
+        dtPresenter.setContent( null,
+                                null,
+                                dtContent,
+                                modellerPresenter,
+                                false );
+        when(view.getLayer()).thenReturn(mock(Layer.class));
+    }
+
+    @Test
+    public void updateColumnAddsToLog() throws MoveColumnVetoException {
+        dtPresenter.updateColumn(new ActionCol52(), new ActionCol52());
+        dtPresenter.updateColumn(new AttributeCol52(), new AttributeCol52());
+        dtPresenter.updateColumn(new ConditionCol52(), new ConditionCol52());
+        dtPresenter.updateColumn(new MetadataCol52(), new MetadataCol52());
+        dtPresenter.updateColumn(new Pattern52(), new ConditionCol52(), new Pattern52(), new ConditionCol52());
+
+        verify(synchronizer, times(4)).updateColumn(any(BaseColumn.class), any(BaseColumn.class));
+        verify(synchronizer).updateColumn(any(Pattern52.class), any(ConditionCol52.class), any(Pattern52.class), any(ConditionCol52.class));
+        verify(model, times(5)).getAuditLog();
+        assertEquals(5, model.getAuditLog().size());
+        for (UpdateColumnAuditLogEntry entry : model.getAuditLog().toArray(new UpdateColumnAuditLogEntry[0])) {
+            assertEquals(diffs, entry.getDiffs());
+        }
+    }
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
@@ -16,12 +16,18 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
+import java.util.List;
 
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
@@ -33,8 +39,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -125,7 +129,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
 
     @Test
     public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
-        final ActionInsertFactCol52 column = new ActionInsertFactCol52();
+        final ActionInsertFactCol52 column = spy( new ActionInsertFactCol52() );
         column.setHeader( "col1" );
         column.setBoundName( "$a" );
         column.setFactType( "Applicant" );
@@ -140,8 +144,11 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 3,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getActionCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
@@ -16,7 +16,14 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
 import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BoundFactUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
@@ -25,8 +32,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -55,7 +60,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
 
     @Test
     public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
-        final ActionRetractFactCol52 column = new ActionRetractFactCol52();
+        final ActionRetractFactCol52 column = spy( new ActionRetractFactCol52() );
         column.setHeader( "col1" );
 
         modelSynchronizer.appendColumn( column );
@@ -64,8 +69,11 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 2,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getActionCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
@@ -16,13 +16,19 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
+import java.util.List;
 
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
@@ -35,8 +41,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -171,7 +175,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
         modelSynchronizer.appendColumn( pattern,
                                         condition );
 
-        final ActionSetFieldCol52 column = new ActionSetFieldCol52();
+        final ActionSetFieldCol52 column = spy( new ActionSetFieldCol52() );
         column.setHeader( "col1" );
         column.setBoundName( "$a" );
         column.setFactField( "age" );
@@ -184,8 +188,11 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 3,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getConditions().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemColumnSynchronizerTest.java
@@ -16,7 +16,14 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
@@ -25,8 +32,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionWorkItemColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -55,7 +60,7 @@ public class ActionWorkItemColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
-        final ActionWorkItemCol52 column = new ActionWorkItemCol52();
+        final ActionWorkItemCol52 column = spy( new ActionWorkItemCol52() );
         column.setHeader( "col1" );
 
         modelSynchronizer.appendColumn( column );
@@ -64,8 +69,11 @@ public class ActionWorkItemColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 2,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getActionCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
@@ -16,7 +16,14 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
@@ -25,8 +32,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -55,7 +60,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
 
     @Test
     public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
-        final ActionWorkItemInsertFactCol52 column = new ActionWorkItemInsertFactCol52();
+        final ActionWorkItemInsertFactCol52 column = spy( new ActionWorkItemInsertFactCol52() );
         column.setHeader( "col1" );
 
         modelSynchronizer.appendColumn( column );
@@ -64,8 +69,11 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 2,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getActionCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
@@ -16,13 +16,19 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
+import java.util.List;
 
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
@@ -33,8 +39,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -89,7 +93,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
 
     @Test
     public void testUpdate() throws ModelSynchronizer.MoveColumnVetoException {
-        final ActionWorkItemSetFieldCol52 column = new ActionWorkItemSetFieldCol52();
+        final ActionWorkItemSetFieldCol52 column = spy( new ActionWorkItemSetFieldCol52() );
         column.setHeader( "col1" );
 
         modelSynchronizer.appendColumn( column );
@@ -98,8 +102,11 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 2,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getActionCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
@@ -16,9 +16,15 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.ArrayList;
+import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
@@ -31,8 +37,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -65,7 +69,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
-        final AttributeCol52 column = new AttributeCol52();
+        final AttributeCol52 column = spy( new AttributeCol52() );
         column.setAttribute( RuleAttributeWidget.SALIENCE_ATTR );
 
         modelSynchronizer.appendColumn( column );
@@ -73,8 +77,11 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
         final AttributeCol52 edited = new AttributeCol52();
         edited.setAttribute( RuleAttributeWidget.ENABLED_ATTR );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getAttributeCols().size() );
@@ -90,7 +97,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
-        final AttributeCol52 column = new AttributeCol52();
+        final AttributeCol52 column = spy( new AttributeCol52() );
         column.setAttribute( RuleAttributeWidget.SALIENCE_ATTR );
 
         modelSynchronizer.appendColumn( column );
@@ -99,8 +106,11 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setAttribute( RuleAttributeWidget.SALIENCE_ATTR );
         edited.setHideColumn( true );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getAttributeCols().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLActionColumnSynchronizerTest.java
@@ -16,11 +16,17 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
+import java.util.List;
 
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLActionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLActionVariableColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
@@ -32,8 +38,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -144,7 +148,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, single variable
-        final BRLActionColumn column = new BRLActionColumn();
+        final BRLActionColumn column = spy( new BRLActionColumn() );
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn( "$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
                                                                               "Applicant",
@@ -172,8 +176,11 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 5, // header, hide, field name, field type, binding
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -192,7 +199,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, multiple variables
-        final BRLActionColumn column = new BRLActionColumn();
+        final BRLActionColumn column = spy( new BRLActionColumn() );
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn( "$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
                                                                               "Applicant",
@@ -226,8 +233,11 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 6, // header, hide, field name, field type, binding, removed column
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -246,7 +256,7 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, multiple variables
-        final BRLActionColumn column = new BRLActionColumn();
+        final BRLActionColumn column = spy( new BRLActionColumn() );
         final BRLActionVariableColumn columnV0 = new BRLActionVariableColumn( "$age",
                                                                               DataType.TYPE_NUMERIC_INTEGER,
                                                                               "Applicant",
@@ -280,8 +290,11 @@ public class BRLActionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 6, // header, hide, field name, field type, binding, removed column
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BRLConditionColumnSynchronizerTest.java
@@ -16,11 +16,17 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.HashMap;
+import java.util.List;
 
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
@@ -33,8 +39,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -145,7 +149,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, single variable
-        final BRLConditionColumn column = new BRLConditionColumn();
+        final BRLConditionColumn column = spy( new BRLConditionColumn() );
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn( "$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
                                                                                     "Applicant",
@@ -173,8 +177,11 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 5, // header, hide, field name, field type, binding
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -193,7 +200,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, multiple variables
-        final BRLConditionColumn column = new BRLConditionColumn();
+        final BRLConditionColumn column = spy( new BRLConditionColumn() );
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn( "$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
                                                                                     "Applicant",
@@ -227,8 +234,11 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 6, // header, hide, field name, field type, binding, removed column
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -247,7 +257,7 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Column, multiple variables
-        final BRLConditionColumn column = new BRLConditionColumn();
+        final BRLConditionColumn column = spy( new BRLConditionColumn() );
         final BRLConditionVariableColumn columnV0 = new BRLConditionVariableColumn( "$age",
                                                                                     DataType.TYPE_NUMERIC_INTEGER,
                                                                                     "Applicant",
@@ -281,8 +291,11 @@ public class BRLConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setHideColumn( true );
         edited.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 6, // header, hide, field name, field type, binding, removed column
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizerTest.java
@@ -170,6 +170,7 @@ public abstract class BaseSynchronizerTest {
 
     protected List<Synchronizer<? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData>> getSynchronizers() {
         final List<Synchronizer<? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData, ? extends MetaData>> synchronizers = new ArrayList<>();
+        synchronizers.add( new ActionColumnSynchronizer() );
         synchronizers.add( new ActionInsertFactColumnSynchronizer() );
         synchronizers.add( new ActionRetractFactColumnSynchronizer() );
         synchronizers.add( new ActionSetFieldColumnSynchronizer() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ConditionColumnSynchronizerTest.java
@@ -16,6 +16,10 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,6 +28,7 @@ import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
@@ -35,8 +40,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -264,11 +267,11 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Pattern, single Condition
-        final Pattern52 pattern = new Pattern52();
+        final Pattern52 pattern = spy( new Pattern52() );
         pattern.setBoundName( "$a" );
         pattern.setFactType( "Applicant" );
 
-        final ConditionCol52 condition = new ConditionCol52();
+        final ConditionCol52 condition = spy( new ConditionCol52() );
         condition.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
         condition.setHeader( "col1" );
         condition.setFactField( "age" );
@@ -287,10 +290,14 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         editedCondition.setFactField( "name" );
         editedCondition.setOperator( "==" );
 
-        modelSynchronizer.updateColumn( pattern,
-                                        condition,
-                                        editedPattern,
-                                        editedCondition );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( pattern,
+                                                                          condition,
+                                                                          editedPattern,
+                                                                          editedCondition );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( pattern ).diff( editedPattern );
+        verify( condition ).diff( editedCondition );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -307,11 +314,11 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
         //Single Pattern, multiple Conditions
-        final Pattern52 pattern = new Pattern52();
+        final Pattern52 pattern = spy( new Pattern52() );
         pattern.setBoundName( "$a" );
         pattern.setFactType( "Applicant" );
 
-        final ConditionCol52 condition1 = new ConditionCol52();
+        final ConditionCol52 condition1 = spy( new ConditionCol52() );
         condition1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
         condition1.setHeader( "col1" );
         condition1.setFactField( "age" );
@@ -339,10 +346,14 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         editedCondition.setFactField( "age" );
         editedCondition.setOperator( "==" );
 
-        modelSynchronizer.updateColumn( pattern,
-                                        condition1,
-                                        editedPattern,
-                                        editedCondition );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( pattern,
+                                                                          condition1,
+                                                                          editedPattern,
+                                                                          editedCondition );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( pattern ).diff( editedPattern );
+        verify( condition1 ).diff( editedCondition );
 
         assertEquals( 4,
                       model.getExpandedColumns().size() );
@@ -362,11 +373,11 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate3() throws ModelSynchronizer.MoveColumnVetoException {
         //Multiple Patterns, multiple Conditions
-        final Pattern52 pattern1 = new Pattern52();
+        final Pattern52 pattern1 = spy( new Pattern52() );
         pattern1.setBoundName( "$a" );
         pattern1.setFactType( "Applicant" );
 
-        final ConditionCol52 condition1 = new ConditionCol52();
+        final ConditionCol52 condition1 = spy( new ConditionCol52() );
         condition1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
         condition1.setHeader( "col1" );
         condition1.setFactField( "age" );
@@ -394,10 +405,14 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         editedCondition.setFactField( "country" );
         editedCondition.setOperator( "==" );
 
-        modelSynchronizer.updateColumn( pattern1,
-                                        condition1,
-                                        editedPattern,
-                                        editedCondition );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( pattern1,
+                                                                          condition1,
+                                                                          editedPattern,
+                                                                          editedCondition );
+        assertEquals( 3,
+                      diffs.size() );
+        verify( pattern1 ).diff( editedPattern );
+        verify( condition1 ).diff( editedCondition );
 
         assertEquals( 4,
                       model.getExpandedColumns().size() );
@@ -417,11 +432,11 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
     @Test
     public void testUpdate4() throws ModelSynchronizer.MoveColumnVetoException {
         //Multiple Patterns, multiple Conditions
-        final Pattern52 pattern1 = new Pattern52();
+        final Pattern52 pattern1 = spy( new Pattern52() );
         pattern1.setBoundName( "$a" );
         pattern1.setFactType( "Applicant" );
 
-        final ConditionCol52 condition1 = new ConditionCol52();
+        final ConditionCol52 condition1 = spy( new ConditionCol52() );
         condition1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
         condition1.setHeader( "col1" );
         condition1.setFactField( "age" );
@@ -440,10 +455,14 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         editedCondition.setFactField( "country" );
         editedCondition.setOperator( "==" );
 
-        modelSynchronizer.updateColumn( pattern1,
-                                        condition1,
-                                        editedPattern,
-                                        editedCondition );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( pattern1,
+                                                                          condition1,
+                                                                          editedPattern,
+                                                                          editedCondition );
+        assertEquals( 3,
+                      diffs.size() );
+        verify( pattern1 ).diff( editedPattern );
+        verify( condition1 ).diff( editedCondition );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );
@@ -460,11 +479,11 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate5() throws ModelSynchronizer.MoveColumnVetoException {
-        final Pattern52 pattern1 = new Pattern52();
+        final Pattern52 pattern1 = spy( new Pattern52() );
         pattern1.setBoundName( "$a" );
         pattern1.setFactType( "Applicant" );
 
-        final ConditionCol52 condition1 = new ConditionCol52();
+        final ConditionCol52 condition1 = spy( new ConditionCol52() );
         condition1.setConstraintValueType( BaseSingleFieldConstraint.TYPE_LITERAL );
         condition1.setFactField( "age" );
         condition1.setOperator( "==" );
@@ -484,10 +503,14 @@ public class ConditionColumnSynchronizerTest extends BaseSynchronizerTest {
         editedCondition.setHideColumn( true );
         editedCondition.setHeader( "updated" );
 
-        modelSynchronizer.updateColumn( pattern1,
-                                        condition1,
-                                        editedPattern,
-                                        editedCondition );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( pattern1,
+                                                                          condition1,
+                                                                          editedPattern,
+                                                                          editedCondition );
+        assertEquals( 2,
+                      diffs.size() );
+        verify( pattern1 ).diff( editedPattern );
+        verify( condition1 ).diff( editedCondition );
 
         assertEquals( 3,
                       model.getExpandedColumns().size() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/MetaDataColumnSynchronizerTest.java
@@ -16,8 +16,14 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
-import java.util.ArrayList;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
@@ -26,8 +32,6 @@ import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOr
 import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleImpl;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
-
-import static org.junit.Assert.*;
 
 public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
 
@@ -57,7 +61,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate1() throws ModelSynchronizer.MoveColumnVetoException {
-        final MetadataCol52 column = new MetadataCol52();
+        final MetadataCol52 column = spy( new MetadataCol52() );
         column.setMetadata( "smurf" );
 
         modelSynchronizer.appendColumn( column );
@@ -65,8 +69,11 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
         final MetadataCol52 edited = new MetadataCol52();
         edited.setMetadata( "changed" );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getMetadataCols().size() );
@@ -81,7 +88,7 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
 
     @Test
     public void testUpdate2() throws ModelSynchronizer.MoveColumnVetoException {
-        final MetadataCol52 column = new MetadataCol52();
+        final MetadataCol52 column = spy( new MetadataCol52() );
         column.setMetadata( "smurf" );
 
         modelSynchronizer.appendColumn( column );
@@ -90,8 +97,11 @@ public class MetaDataColumnSynchronizerTest extends BaseSynchronizerTest {
         edited.setMetadata( "smurf" );
         edited.setHideColumn( true );
 
-        modelSynchronizer.updateColumn( column,
-                                        edited );
+        List<BaseColumnFieldDiff> diffs = modelSynchronizer.updateColumn( column,
+                                                                          edited );
+        assertEquals( 1,
+                      diffs.size() );
+        verify( column ).diff( edited );
 
         assertEquals( 1,
                       model.getMetadataCols().size() );


### PR DESCRIPTION
... and clean up AuditLogEntryCellHelper a tiny bit.

This PR relies (a bit) on https://github.com/droolsjbpm/drools/pull/820.

(part n+1 of moving-tests-to-community series)