### PR TITLE
GUVNOR-2593: Guided Decision Table Editor: Column resizing should be persisted

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseEnumSingleSelectUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseEnumSingleSelectUiColumn.java
@@ -34,7 +34,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public abstract class BaseEnumSingleSelectUiColumn<T, MVW extends ListBox, SVW extends Widget, MVE extends MultiValueDOMElement<T, MVW>, SVE extends SingleValueDOMElement<T, SVW>> extends BaseUiSingletonColumn<T, MVW, MVE, MultiValueSingletonDOMElementFactory<T, MVW, MVE>> {
+public abstract class BaseEnumSingleSelectUiColumn<T, MVW extends ListBox, SVW extends Widget, MVE extends MultiValueDOMElement<T, MVW>, SVE extends SingleValueDOMElement<T, SVW>> extends BaseSingletonDOMElementUiColumn<T, MVW, MVE, MultiValueSingletonDOMElementFactory<T, MVW, MVE>> {
 
     protected final String factType;
     protected final String factField;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseMultipleDOMElementUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseMultipleDOMElementUiColumn.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.drools.workbench.screens.guided.dtable.client.widget.table.columns;
+
+import java.util.List;
+
+import com.google.gwt.user.client.ui.Widget;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.HasMultipleDOMElementResources;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.MultipleDOMElementFactory;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.multiple.impl.BaseGridColumnMultipleDOMElementRenderer;
+
+/**
+ * Base column for Decision Tables.
+ * @param <T> The Type of value presented by this column
+ * @param <F> The Factory to create DOMElements for this column
+ */
+public abstract class BaseMultipleDOMElementUiColumn<T, W extends Widget, E extends BaseDOMElement, F extends MultipleDOMElementFactory<W, E>> extends BaseUiColumn<T> implements HasMultipleDOMElementResources {
+
+    protected F factory;
+
+    public BaseMultipleDOMElementUiColumn( final List<HeaderMetaData> headerMetaData,
+                                           final BaseGridColumnMultipleDOMElementRenderer<T, W, E> columnRenderer,
+                                           final double width,
+                                           final boolean isResizable,
+                                           final boolean isVisible,
+                                           final GuidedDecisionTablePresenter.Access access,
+                                           final F factory ) {
+        super( headerMetaData,
+               columnRenderer,
+               width,
+               isResizable,
+               isVisible,
+               access );
+        setResizable( isResizable );
+        setVisible( isVisible );
+        this.factory = factory;
+    }
+
+    @Override
+    public void initialiseResources() {
+        factory.initialiseResources();
+    }
+
+    @Override
+    public void freeUnusedResources() {
+        factory.freeUnusedResources();
+    }
+
+    @Override
+    public void destroyResources() {
+        factory.destroyResources();
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseSingletonDOMElementUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseSingletonDOMElementUiColumn.java
@@ -26,7 +26,6 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.model.Guid
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
-import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
@@ -39,25 +38,25 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.Gri
  * @param <T> The Type of value presented by this column
  * @param <F> The Factory to create DOMElements for this column
  */
-public abstract class BaseUiSingletonColumn<T, W extends Widget, E extends BaseDOMElement, F extends SingletonDOMElementFactory<W, E>> extends BaseGridColumn<T> implements HasSingletonDOMElementResource {
+public abstract class BaseSingletonDOMElementUiColumn<T, W extends Widget, E extends BaseDOMElement, F extends SingletonDOMElementFactory<W, E>> extends BaseUiColumn<T> implements HasSingletonDOMElementResource {
 
     protected F factory;
 
-    protected GuidedDecisionTablePresenter.Access access;
-
-    public BaseUiSingletonColumn( final List<HeaderMetaData> headerMetaData,
-                                  final BaseGridColumnSingletonDOMElementRenderer<T, W, E> columnRenderer,
-                                  final double width,
-                                  final boolean isResizable,
-                                  final boolean isVisible,
-                                  final GuidedDecisionTablePresenter.Access access,
-                                  final F factory ) {
+    public BaseSingletonDOMElementUiColumn( final List<HeaderMetaData> headerMetaData,
+                                            final BaseGridColumnSingletonDOMElementRenderer<T, W, E> columnRenderer,
+                                            final double width,
+                                            final boolean isResizable,
+                                            final boolean isVisible,
+                                            final GuidedDecisionTablePresenter.Access access,
+                                            final F factory ) {
         super( headerMetaData,
                columnRenderer,
-               width );
+               width,
+               isResizable,
+               isVisible,
+               access );
         setResizable( isResizable );
         setVisible( isVisible );
-        this.access = access;
         this.factory = factory;
     }
 
@@ -81,10 +80,6 @@ public abstract class BaseUiSingletonColumn<T, W extends Widget, E extends BaseD
     @Override
     public void destroyResources() {
         factory.destroyResources();
-    }
-
-    public boolean isEditable() {
-        return access.isEditable();
     }
 
     protected abstract void doEdit( final GridCell<T> cell,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BaseUiColumn.java
@@ -1,74 +1,69 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.drools.workbench.screens.guided.dtable.client.widget.table.columns;
 
 import java.util.List;
 
-import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
-import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
-import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.HasMultipleDOMElementResources;
-import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.MultipleDOMElementFactory;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.multiple.impl.BaseGridColumnMultipleDOMElementRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
 
 /**
  * Base column for Decision Tables.
  * @param <T> The Type of value presented by this column
- * @param <F> The Factory to create DOMElements for this column
  */
-public abstract class BaseUiColumn<T, W extends Widget, E extends BaseDOMElement, F extends MultipleDOMElementFactory<W, E>> extends BaseGridColumn<T> implements HasMultipleDOMElementResources {
+public abstract class BaseUiColumn<T> extends BaseGridColumn<T> {
 
-    protected F factory;
-
-    protected GuidedDecisionTablePresenter.Access access;
+    private GuidedDecisionTablePresenter.Access access;
+    private ColumnResizeListener columnResizeListener;
 
     public BaseUiColumn( final List<HeaderMetaData> headerMetaData,
-                         final BaseGridColumnMultipleDOMElementRenderer<T, W, E> columnRenderer,
+                         final GridColumnRenderer<T> columnRenderer,
                          final double width,
                          final boolean isResizable,
                          final boolean isVisible,
-                         final GuidedDecisionTablePresenter.Access access,
-                         final F factory ) {
+                         final GuidedDecisionTablePresenter.Access access ) {
         super( headerMetaData,
                columnRenderer,
                width );
         setResizable( isResizable );
         setVisible( isVisible );
         this.access = access;
-        this.factory = factory;
-    }
-
-    @Override
-    public void initialiseResources() {
-        factory.initialiseResources();
-    }
-
-    @Override
-    public void freeUnusedResources() {
-        factory.freeUnusedResources();
-    }
-
-    @Override
-    public void destroyResources() {
-        factory.destroyResources();
     }
 
     public boolean isEditable() {
         return access.isEditable();
+    }
+
+    public void setColumnResizeListener( final ColumnResizeListener columnResizeListener ) {
+        this.columnResizeListener = columnResizeListener;
+    }
+
+    @Override
+    public void setWidth( final double width ) {
+        super.setWidth( width );
+        if ( columnResizeListener != null ) {
+            columnResizeListener.onResizeColumn( width );
+        }
+    }
+
+    public interface ColumnResizeListener {
+
+        void onResizeColumn( final double width );
+
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BigDecimalUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BigDecimalUiColumn.java
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class BigDecimalUiColumn extends BaseUiSingletonColumn<BigDecimal, NumericBigDecimalTextBox, TextBoxDOMElement<BigDecimal, NumericBigDecimalTextBox>, TextBoxBigDecimalSingletonDOMElementFactory> {
+public class BigDecimalUiColumn extends BaseSingletonDOMElementUiColumn<BigDecimal, NumericBigDecimalTextBox, TextBoxDOMElement<BigDecimal, NumericBigDecimalTextBox>, TextBoxBigDecimalSingletonDOMElementFactory> {
 
     public BigDecimalUiColumn( final List<HeaderMetaData> headerMetaData,
                                final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BigIntegerUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BigIntegerUiColumn.java
@@ -28,7 +28,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class BigIntegerUiColumn extends BaseUiSingletonColumn<BigInteger, NumericBigIntegerTextBox, TextBoxDOMElement<BigInteger, NumericBigIntegerTextBox>, TextBoxBigIntegerSingletonDOMElementFactory> {
+public class BigIntegerUiColumn extends BaseSingletonDOMElementUiColumn<BigInteger, NumericBigIntegerTextBox, TextBoxDOMElement<BigInteger, NumericBigIntegerTextBox>, TextBoxBigIntegerSingletonDOMElementFactory> {
 
     public BigIntegerUiColumn( final List<HeaderMetaData> headerMetaData,
                                final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BooleanUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BooleanUiColumn.java
@@ -23,7 +23,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.CheckBoxDOMEleme
 import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.impl.CheckBoxDOMElementFactory;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.multiple.impl.BooleanColumnDOMElementRenderer;
 
-public class BooleanUiColumn extends BaseUiColumn<Boolean, CheckBox, CheckBoxDOMElement, CheckBoxDOMElementFactory> {
+public class BooleanUiColumn extends BaseMultipleDOMElementUiColumn<Boolean, CheckBox, CheckBoxDOMElement, CheckBoxDOMElementFactory> {
 
     public BooleanUiColumn( final List<HeaderMetaData> headerMetaData,
                             final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BoundFactUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/BoundFactUiColumn.java
@@ -29,7 +29,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class BoundFactUiColumn extends BaseUiSingletonColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
+public class BoundFactUiColumn extends BaseSingletonDOMElementUiColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
 
     private final GuidedDecisionTableView.Presenter presenter;
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ByteUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ByteUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class ByteUiColumn extends BaseUiSingletonColumn<Byte, NumericByteTextBox, TextBoxDOMElement<Byte, NumericByteTextBox>, TextBoxByteSingletonDOMElementFactory> {
+public class ByteUiColumn extends BaseSingletonDOMElementUiColumn<Byte, NumericByteTextBox, TextBoxDOMElement<Byte, NumericByteTextBox>, TextBoxByteSingletonDOMElementFactory> {
 
     public ByteUiColumn( final List<HeaderMetaData> headerMetaData,
                          final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DateUiColumn.java
@@ -30,7 +30,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class DateUiColumn extends BaseUiSingletonColumn<Date, DatePicker, DatePickerDOMElement, DatePickerSingletonDOMElementFactory> {
+public class DateUiColumn extends BaseSingletonDOMElementUiColumn<Date, DatePicker, DatePickerDOMElement, DatePickerSingletonDOMElementFactory> {
 
     private static final String droolsDateFormat = ApplicationPreferences.getDroolsDateFormat();
     private static final DateTimeFormat dateTimeFormat = DateTimeFormat.getFormat( droolsDateFormat );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DialectUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DialectUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class DialectUiColumn extends BaseUiSingletonColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
+public class DialectUiColumn extends BaseSingletonDOMElementUiColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
 
     public DialectUiColumn( final List<HeaderMetaData> headerMetaData,
                             final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DoubleUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/DoubleUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class DoubleUiColumn extends BaseUiSingletonColumn<Double, NumericDoubleTextBox, TextBoxDOMElement<Double, NumericDoubleTextBox>, TextBoxDoubleSingletonDOMElementFactory> {
+public class DoubleUiColumn extends BaseSingletonDOMElementUiColumn<Double, NumericDoubleTextBox, TextBoxDOMElement<Double, NumericDoubleTextBox>, TextBoxDoubleSingletonDOMElementFactory> {
 
     public DoubleUiColumn( final List<HeaderMetaData> headerMetaData,
                            final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/EnumMultiSelectUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/EnumMultiSelectUiColumn.java
@@ -32,7 +32,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class EnumMultiSelectUiColumn extends BaseUiSingletonColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
+public class EnumMultiSelectUiColumn extends BaseSingletonDOMElementUiColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
 
     private final String factType;
     private final String factField;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/FloatUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/FloatUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class FloatUiColumn extends BaseUiSingletonColumn<Float, NumericFloatTextBox, TextBoxDOMElement<Float, NumericFloatTextBox>, TextBoxFloatSingletonDOMElementFactory> {
+public class FloatUiColumn extends BaseSingletonDOMElementUiColumn<Float, NumericFloatTextBox, TextBoxDOMElement<Float, NumericFloatTextBox>, TextBoxFloatSingletonDOMElementFactory> {
 
     public FloatUiColumn( final List<HeaderMetaData> headerMetaData,
                           final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/IntegerUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/IntegerUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class IntegerUiColumn extends BaseUiSingletonColumn<Integer, NumericIntegerTextBox, TextBoxDOMElement<Integer, NumericIntegerTextBox>, TextBoxIntegerSingletonDOMElementFactory> {
+public class IntegerUiColumn extends BaseSingletonDOMElementUiColumn<Integer, NumericIntegerTextBox, TextBoxDOMElement<Integer, NumericIntegerTextBox>, TextBoxIntegerSingletonDOMElementFactory> {
 
     public IntegerUiColumn( final List<HeaderMetaData> headerMetaData,
                             final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/LongUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/LongUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class LongUiColumn extends BaseUiSingletonColumn<Long, NumericLongTextBox, TextBoxDOMElement<Long, NumericLongTextBox>, TextBoxLongSingletonDOMElementFactory> {
+public class LongUiColumn extends BaseSingletonDOMElementUiColumn<Long, NumericLongTextBox, TextBoxDOMElement<Long, NumericLongTextBox>, TextBoxLongSingletonDOMElementFactory> {
 
     public LongUiColumn( final List<HeaderMetaData> headerMetaData,
                          final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/NumericUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/NumericUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class NumericUiColumn extends BaseUiSingletonColumn<Number, NumericBigDecimalTextBox, TextBoxDOMElement<Number, NumericBigDecimalTextBox>, TextBoxNumericSingletonDOMElementFactory> {
+public class NumericUiColumn extends BaseSingletonDOMElementUiColumn<Number, NumericBigDecimalTextBox, TextBoxDOMElement<Number, NumericBigDecimalTextBox>, TextBoxNumericSingletonDOMElementFactory> {
 
     public NumericUiColumn( final List<HeaderMetaData> headerMetaData,
                             final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ShortUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ShortUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class ShortUiColumn extends BaseUiSingletonColumn<Short, NumericShortTextBox, TextBoxDOMElement<Short, NumericShortTextBox>, TextBoxShortSingletonDOMElementFactory> {
+public class ShortUiColumn extends BaseSingletonDOMElementUiColumn<Short, NumericShortTextBox, TextBoxDOMElement<Short, NumericShortTextBox>, TextBoxShortSingletonDOMElementFactory> {
 
     public ShortUiColumn( final List<HeaderMetaData> headerMetaData,
                           final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/StringUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/StringUiColumn.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class StringUiColumn extends BaseUiSingletonColumn<String, TextBox, TextBoxDOMElement<String, TextBox>, TextBoxSingletonDOMElementFactory<String, TextBox>> {
+public class StringUiColumn extends BaseSingletonDOMElementUiColumn<String, TextBox, TextBoxDOMElement<String, TextBox>, TextBoxSingletonDOMElementFactory<String, TextBox>> {
 
     public StringUiColumn( final List<HeaderMetaData> headerMetaData,
                            final double width,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ValueListUiColumn.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/ValueListUiColumn.java
@@ -29,7 +29,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 
-public class ValueListUiColumn extends BaseUiSingletonColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
+public class ValueListUiColumn extends BaseSingletonDOMElementUiColumn<String, ListBox, ListBoxDOMElement<String, ListBox>, ListBoxSingletonDOMElementFactory<String, ListBox>> {
 
     private final Map<String, String> valueListLookup = new HashMap<String, String>();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImpl.java
@@ -25,6 +25,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.BaseColumnConverter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
@@ -69,9 +70,13 @@ public class GridWidgetColumnFactoryImpl implements GridWidgetColumnFactory {
                                         final GuidedDecisionTableView gridWidget ) {
         for ( BaseColumnConverter converter : converters ) {
             if ( converter.handles( column ) ) {
-                return converter.convertColumn( column,
-                                                access,
-                                                gridWidget );
+                final GridColumn<?> uiColumn = converter.convertColumn( column,
+                                                                        access,
+                                                                        gridWidget );
+                if ( uiColumn instanceof BaseUiColumn ) {
+                    ( (BaseUiColumn) uiColumn ).setColumnResizeListener( ( double width ) -> column.setWidth( ( (int) width ) ) );
+                }
+                return uiColumn;
             }
         }
         throw new IllegalArgumentException( "Column '" + column.getHeader() + "' was not converted." );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/BaseConverterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/BaseConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.BaseColumnConverter;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.ColumnUtilities;
+import org.junit.Before;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.mockito.Mock;
+
+public abstract class BaseConverterTest {
+
+    @Mock
+    protected GuidedDecisionTableView gridWidget;
+    protected GuidedDecisionTableView.Presenter presenter;
+
+    protected GuidedDecisionTable52 model;
+    protected AsyncPackageDataModelOracle oracle;
+    protected ColumnUtilities columnUtilities;
+
+    private final List<BaseColumnConverter> converters = new ArrayList<BaseColumnConverter>();
+
+    @Before
+    public void setup() {
+        this.model = getModel();
+        this.oracle = getOracle();
+        this.presenter = getPresenter();
+        this.columnUtilities = new ColumnUtilities( model,
+                                                    oracle );
+        for ( BaseColumnConverter bcc : getConverters() ) {
+            bcc.initialise( model,
+                            oracle,
+                            columnUtilities,
+                            presenter );
+        }
+    }
+
+    protected abstract GuidedDecisionTable52 getModel();
+
+    protected abstract AsyncPackageDataModelOracle getOracle();
+
+    protected abstract GuidedDecisionTableView.Presenter getPresenter();
+
+    protected List<BaseColumnConverter> getConverters() {
+        if(!converters.isEmpty()) {
+            return converters;
+        }
+        converters.add( new ActionInsertFactColumnConverter() );
+        converters.add( new ActionRetractFactColumnConverter() );
+        converters.add( new ActionSetFieldColumnConverter() );
+        converters.add( new ActionWorkItemColumnConverter() );
+        converters.add( new ActionWorkItemInsertFactColumnConverter() );
+        converters.add( new ActionWorkItemSetFieldColumnConverter() );
+        converters.add( new AttributeColumnConverter() );
+        converters.add( new BRLActionVariableColumnConverter() );
+        converters.add( new BRLConditionVariableColumnConverter() );
+        converters.add( new ConditionColumnConverter() );
+        converters.add( new DescriptionColumnConverter() );
+        converters.add( new LimitedEntryColumnConverter() );
+        converters.add( new MetaDataColumnConverter() );
+        converters.add( new RowNumberColumnConverter() );
+        return converters;
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImplTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/converters/column/impl/GridWidgetColumnFactoryImplTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.impl;
+
+import java.util.ArrayList;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.drools.workbench.models.datamodel.oracle.DataType;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.BaseColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
+import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DescriptionCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.models.guided.dtable.shared.model.MetadataCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.models.guided.dtable.shared.model.RowNumberCol52;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableModellerView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.model.converters.column.GridWidgetColumnFactory;
+import org.drools.workbench.screens.guided.rule.client.editor.RuleAttributeWidget;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridWidgetColumnFactoryImplTest extends BaseConverterTest {
+
+    @Mock
+    private GuidedDecisionTable52 model;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracle;
+
+    @Mock
+    private GuidedDecisionTableView.Presenter dtPresenter;
+
+    @Mock
+    private GuidedDecisionTableModellerView dtModellerView;
+
+    @Mock
+    private GuidedDecisionTableModellerView.Presenter dtModellerPresenter;
+
+    @Mock
+    private GridLayer gridLayer;
+
+    private GridWidgetColumnFactory factory;
+
+    private GuidedDecisionTablePresenter.Access access;
+
+    @Before
+    public void setup() {
+        super.setup();
+        factory = new GridWidgetColumnFactoryImpl();
+        factory.setConverters( getConverters() );
+
+        access = new GuidedDecisionTablePresenter.Access();
+    }
+
+    @Override
+    protected GuidedDecisionTable52 getModel() {
+        return model;
+    }
+
+    @Override
+    protected AsyncPackageDataModelOracle getOracle() {
+        return oracle;
+    }
+
+    @Override
+    protected GuidedDecisionTableView.Presenter getPresenter() {
+        when( dtPresenter.getModellerPresenter() ).thenReturn( dtModellerPresenter );
+        when( dtModellerPresenter.getView() ).thenReturn( dtModellerView );
+        when( dtModellerView.getGridLayerView() ).thenReturn( gridLayer );
+
+        return dtPresenter;
+    }
+
+    @Test
+    public void columnResizingListenerSetup_RowNumberColumn() {
+        final BaseColumn column = new RowNumberCol52();
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertFalse( uiColumn instanceof BaseUiColumn );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_DescriptionColumn() {
+        final BaseColumn column = new DescriptionCol52();
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_MetadataColumn() {
+        final MetadataCol52 column = new MetadataCol52();
+        column.setMetadata( "metadata" );
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_AttributeColumn() {
+        final AttributeCol52 column = new AttributeCol52();
+        column.setAttribute( RuleAttributeWidget.SALIENCE_ATTR );
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_ConditionColumn() {
+        final Pattern52 pattern = mock( Pattern52.class );
+        final ConditionCol52 column = new ConditionCol52();
+        column.setFactField( "MyField" );
+        column.setHeader( "MyColumn" );
+
+        when( model.getPattern( eq( column ) ) ).thenReturn( pattern );
+        when( pattern.getFactType() ).thenReturn( "MyFact" );
+        when( oracle.getFieldType( "MyFact",
+                                   "MyField" ) ).thenReturn( DataType.TYPE_STRING );
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_ActionSetFieldColumn() {
+        final Pattern52 pattern = mock( Pattern52.class );
+        final ActionSetFieldCol52 column = new ActionSetFieldCol52();
+        column.setFactField( "MyField" );
+        column.setHeader( "MyColumn" );
+        column.setBoundName( "$f" );
+
+        when( model.getConditions() ).thenReturn( new ArrayList<CompositeColumn<? extends BaseColumn>>() {{
+            add( pattern );
+        }} );
+        when( pattern.getFactType() ).thenReturn( "MyFact" );
+        when( pattern.getBoundName() ).thenReturn( "$f" );
+        when( pattern.isBound() ).thenReturn( true );
+        when( oracle.getFieldType( "MyFact",
+                                   "MyField" ) ).thenReturn( DataType.TYPE_STRING );
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+    @Test
+    public void columnResizingListenerSetup_ActionInsertFactColumn() {
+        final ActionInsertFactCol52 column = new ActionInsertFactCol52();
+        column.setFactType( "MyFact" );
+        column.setFactField( "MyField" );
+        column.setHeader( "MyColumn" );
+
+        when( oracle.getFieldType( "MyFact",
+                                   "MyField" ) ).thenReturn( DataType.TYPE_STRING );
+
+        final GridColumn<?> uiColumn = factory.convertColumn( column,
+                                                              access,
+                                                              gridWidget );
+
+        assertTrue( uiColumn instanceof BaseUiColumn );
+
+        uiColumn.setWidth( 200.0 );
+        assertEquals( 200,
+                      column.getWidth() );
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/linkmanager/impl/DefaultGuidedDecisionTableLinkManagerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/linkmanager/impl/DefaultGuidedDecisionTableLinkManagerTest.java
@@ -25,7 +25,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -114,15 +114,15 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
 
         //Mock uiModel's columns
         final GridData dtPresenter1UiModel = dtPresenter1.getView().getModel();
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
 
         final GridData dtPresenter2UiModel = dtPresenter2.getView().getModel();
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
 
         manager.link( dtPresenter1,
                       new HashSet<GuidedDecisionTableView.Presenter>() {{
@@ -172,14 +172,14 @@ public class DefaultGuidedDecisionTableLinkManagerTest {
 
         //Mock uiModel's columns
         final GridData dtPresenter1UiModel = dtPresenter1.getView().getModel();
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter1UiModel.appendColumn( mock( BaseUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter1UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
 
         final GridData dtPresenter2UiModel = dtPresenter2.getView().getModel();
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
-        dtPresenter2UiModel.appendColumn( mock( BaseUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
+        dtPresenter2UiModel.appendColumn( mock( BaseMultipleDOMElementUiColumn.class ) );
 
         manager.link( dtPresenter1,
                       new HashSet<GuidedDecisionTableView.Presenter>() {{

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionInsertFactColumnSynchronizerTest.java
@@ -28,8 +28,8 @@ import org.drools.workbench.models.datamodel.oracle.FieldAccessorsAndMutators;
 import org.drools.workbench.models.datamodel.oracle.ModelField;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseSingletonDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
@@ -97,7 +97,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof IntegerUiColumn );
         assertEquals( true,
-                      ( (BaseUiSingletonColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseSingletonDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test
@@ -118,7 +118,7 @@ public class ActionInsertFactColumnSynchronizerTest extends BaseSynchronizerTest
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
 
         //Test row append (boolean cells should be instantiated for Model and UiModel)
         modelSynchronizer.appendRow();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionRetractFactColumnSynchronizerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionRetractFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseSingletonDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BoundFactUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public class ActionRetractFactColumnSynchronizerTest extends BaseSynchronizerTes
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BoundFactUiColumn );
         assertEquals( true,
-                      ( (BaseUiSingletonColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseSingletonDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionSetFieldColumnSynchronizerTest.java
@@ -31,7 +31,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionSetFieldCol5
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseSingletonDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.StringUiColumn;
@@ -114,7 +114,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 3 ) instanceof IntegerUiColumn );
         assertEquals( true,
-                      ( (BaseUiSingletonColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseSingletonDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test
@@ -150,7 +150,7 @@ public class ActionSetFieldColumnSynchronizerTest extends BaseSynchronizerTest {
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 3 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiSingletonColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseSingletonDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
 
         //Test row append (boolean cells should be instantiated for Model and UiModel)
         modelSynchronizer.appendRow();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemColumnSynchronizerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public class ActionWorkItemColumnSynchronizerTest extends BaseSynchronizerTest {
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemInsertFactColumnSynchronizerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -55,7 +55,7 @@ public class ActionWorkItemInsertFactColumnSynchronizerTest extends BaseSynchron
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ActionWorkItemSetFieldColumnSynchronizerTest.java
@@ -31,7 +31,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.ActionWorkItemSetF
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -88,7 +88,7 @@ public class ActionWorkItemSetFieldColumnSynchronizerTest extends BaseSynchroniz
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/AttributeColumnSynchronizerTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.BaseColumnFieldDiff;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiSingletonColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseSingletonDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.IntegerUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.SalienceUiColumn;
@@ -64,7 +64,7 @@ public class AttributeColumnSynchronizerTest extends BaseSynchronizerTest {
         assertEquals( RuleAttributeWidget.SALIENCE_ATTR,
                       uiModel.getColumns().get( 2 ).getHeaderMetaData().get( 0 ).getTitle() );
         assertEquals( true,
-                      ( (BaseUiSingletonColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseSingletonDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLActionColumnSynchronizerTest.java
@@ -17,7 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLActionColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -50,7 +50,7 @@ public class LimitedEntryBRLActionColumnSynchronizerTest extends BaseSynchronize
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/LimitedEntryBRLConditionColumnSynchronizerTest.java
@@ -19,7 +19,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.model.syn
 import org.drools.workbench.models.guided.dtable.shared.model.BRLConditionVariableColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.CompositeColumn;
 import org.drools.workbench.models.guided.dtable.shared.model.LimitedEntryBRLConditionColumn;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseUiColumn;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BaseMultipleDOMElementUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class LimitedEntryBRLConditionColumnSynchronizerTest extends BaseSynchron
                       uiModel.getColumns().size() );
         assertTrue( uiModel.getColumns().get( 2 ) instanceof BooleanUiColumn );
         assertEquals( true,
-                      ( (BaseUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
+                      ( (BaseMultipleDOMElementUiColumn) uiModel.getColumns().get( 2 ) ).isEditable() );
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2593

```wires-grids``` columns have their ```width``` property set as the User resizes them; this however was not copied to the ```GuidedDecisionTable52``` related ```BaseColumn``` instances that form the persisted state. Hence when the UI was saved the column widths were not saved. 