### PR TITLE
GUVNOR-2604: Guided Decision Table Editor: Column definitions DisclosurePanel should scroll if content exceeds available height

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -11,6 +11,7 @@ import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Transform;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.ContextMenuEvent;
@@ -36,6 +37,7 @@ import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionCol52;
@@ -220,13 +222,13 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         config.add( newColumn() );
 
         disclosurePanelMetaData = setupDisclosurePanel( GuidedDecisionTableConstants.INSTANCE.MetadataColumns(),
-                                                        getMetaDataWidget() );
+                                                        wrapDisclosurePanelContent( getMetaDataWidget() ) );
         disclosurePanelAttributes = setupDisclosurePanel( GuidedDecisionTableConstants.INSTANCE.AttributeColumns(),
-                                                          getAttributesWidget() );
+                                                          wrapDisclosurePanelContent( getAttributesWidget() ) );
         disclosurePanelConditions = setupDisclosurePanel( GuidedDecisionTableConstants.INSTANCE.ConditionColumns(),
-                                                          getConditionsWidget() );
+                                                          wrapDisclosurePanelContent( getConditionsWidget() ) );
         disclosurePanelActions = setupDisclosurePanel( GuidedDecisionTableConstants.INSTANCE.ActionColumns(),
-                                                       getActionsWidget() );
+                                                       wrapDisclosurePanelContent( getActionsWidget() ) );
 
         config.add( disclosurePanelMetaData );
         config.add( disclosurePanelAttributes );
@@ -524,6 +526,14 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
     private Widget getAttributesWidget() {
         attributeConfigWidget = new VerticalPanel();
         return attributeConfigWidget;
+    }
+
+    private Widget wrapDisclosurePanelContent( final Widget content ) {
+        final SimplePanel container = new SimplePanel();
+        container.getElement().getStyle().setProperty( "maxHeight", "200px" );
+        container.getElement().getStyle().setOverflowY( Style.Overflow.SCROLL );
+        container.add( content );
+        return container;
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2604

It should be noted (and I have put similar comment on the JIRA) this is a temporary workaround as all peripheral screens and widgets relating to column definition(s) are to be rewritten as Phase 3 of the editor re-write. 