### PR TITLE
Include guvnor client-side exclusions in beans.xml of drools-wb-webapp module

### DIFF
--- a/drools-wb-webapp/src/main/webapp/WEB-INF/beans.xml
+++ b/drools-wb-webapp/src/main/webapp/WEB-INF/beans.xml
@@ -20,22 +20,33 @@
     <exclude name="org.drools.workbench.screens.globals.client.**"/>
     <exclude name="org.drools.workbench.screens.enums.client.**"/>
 
+    <exclude name="org.guvnor.asset.management.client.**"/>
+    <exclude name="org.guvnor.client.**"/>
+    <exclude name="org.guvnor.common.services.project.client.**"/>
+    <exclude name="org.guvnor.common.services.workingset.client.**"/>
+    <exclude name="org.guvnor.inbox.client.**"/>
+    <exclude name="org.guvnor.messageconsole.client.**"/>
+    <exclude name="org.guvnor.m2repo.client.**"/>
+    <exclude name="org.guvnor.organizationalunit.manager.client.**"/>
+    <exclude name="org.guvnor.structure.client.**"/>
+
     <exclude name="org.kie.workbench.common.screens.contributors.client.**"/>
     <exclude name="org.kie.workbench.common.screens.datamodeller.client.**"/>
     <exclude name="org.kie.workbench.common.screens.defaulteditor.client.**"/>
+    <exclude name="org.kie.workbench.common.screens.examples.client.**"/>
+    <exclude name="org.kie.workbench.common.screens.explorer.client.**"/>
     <exclude name="org.kie.workbench.common.screens.home.client.**"/>
     <exclude name="org.kie.workbench.common.screens.javaeditor.client.**"/>
     <exclude name="org.kie.workbench.common.screens.projecteditor.client.**"/>
-    <exclude name="org.kie.workbench.common.screens.explorer.client.**"/>
     <exclude name="org.kie.workbench.common.screens.projectimportsscreen.client.**"/>
     <exclude name="org.kie.workbench.common.screens.search.client.**"/>
     <exclude name="org.kie.workbench.common.screens.server.management.client.**"/>
     <exclude name="org.kie.workbench.common.screens.social.hp.client.**"/>
-    <exclude name="org.kie.workbench.common.workbench.client.**"/>
     <exclude name="org.kie.workbench.common.widgets.client.**"/>
     <exclude name="org.kie.workbench.common.widgets.configresource.client.**"/>
     <exclude name="org.kie.workbench.common.widgets.decoratedgrid.client.**"/>
     <exclude name="org.kie.workbench.common.widgets.metadata.client.**"/>
+    <exclude name="org.kie.workbench.common.workbench.client.**"/>
 
   </scan>
 </beans>


### PR DESCRIPTION
This is required when running the workbench in multi module setup which includes guvnor. Includes additional exclusion for kie-wb-common module.