### PR TITLE
GUVNOR-2689: Guided Decision Tables: Using DatePickers to set date-effective/date-expired causes controls to disappear

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/DTCellValueWidgetFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/DTCellValueWidgetFactory.java
@@ -18,7 +18,6 @@ package org.drools.workbench.screens.guided.dtable.client.widget;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -880,12 +879,7 @@ public class DTCellValueWidgetFactory {
         final DatePicker datePicker = new DatePicker( allowEmptyValues );
 
         // Wire up update handler
-        datePicker.addValueChangeHandler( new ValueChangeHandler<Date>() {
-            @Override
-            public void onValueChange( final ValueChangeEvent<Date> event ) {
-                value.setDateValue( datePicker.getValue() );
-            }
-        } );
+        datePicker.addChangeDateHandler( ( e ) -> value.setDateValue( datePicker.getValue() ) );
 
         datePicker.setFormat( DATE_FORMAT );
         datePicker.setValue( value.getDateValue() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/DefaultValueWidgetFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/DefaultValueWidgetFactory.java
@@ -222,14 +222,11 @@ public class DefaultValueWidgetFactory {
                 final DatePicker datePicker = new DatePicker();
 
                 // Wire up update handler
-                datePicker.addValueChangeHandler( new ValueChangeHandler<Date>() {
-                    @Override
-                    public void onValueChange( final ValueChangeEvent<Date> event ) {
-                        DTCellValue52 clonedDefaultValue = defaultValue.cloneDefaultValueCell();
-                        defaultValue.setDateValue( datePicker.getValue() );
-                        defaultValueChangedEventHandler.onDefaultValueChanged( new DefaultValueChangedEvent( defaultValue,
-                                                                                                             clonedDefaultValue ) );
-                    }
+                datePicker.addChangeDateHandler( ( e ) -> {
+                    DTCellValue52 editedDefaultValue = defaultValue.cloneDefaultValueCell();
+                    editedDefaultValue.setDateValue( datePicker.getValue() );
+                    defaultValueChangedEventHandler.onDefaultValueChanged( new DefaultValueChangedEvent( defaultValue,
+                                                                                                         editedDefaultValue ) );
                 } );
 
                 final Date dateValue = defaultValue.getDateValue();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactory.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/columns/dom/datepicker/DatePickerSingletonDOMElementFactory.java
@@ -18,10 +18,6 @@ package org.drools.workbench.screens.guided.dtable.client.widget.table.columns.d
 import java.util.Date;
 
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.BlurEvent;
-import com.google.gwt.event.dom.client.BlurHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.dom.textbox.SingleValueSingletonDOMElementFactory;
@@ -70,25 +66,16 @@ public class DatePickerSingletonDOMElementFactory extends SingleValueSingletonDO
                                            gridLayer,
                                            gridWidget );
 
-        widget.addValueChangeHandler( new ValueChangeHandler<Date>() {
-            @Override
-            public void onValueChange( final ValueChangeEvent event ) {
-                destroyResources();
-                gridLayer.batch();
-                gridPanel.setFocus( true );
-            }
-        } );
-
-        widget.addBlurHandler( new BlurHandler() {
-            @Override
-            public void onBlur( final BlurEvent event ) {
-                destroyResources();
-                gridLayer.batch();
-                gridPanel.setFocus( true );
-            }
-        } );
+        widget.addChangeDateHandler( ( e ) -> doValueUpdate() );
+        widget.addBlurHandler( ( e ) -> doValueUpdate() );
 
         return e;
+    }
+
+    private void doValueUpdate() {
+        destroyResources();
+        gridLayer.batch();
+        gridPanel.setFocus( true );
     }
 
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2689

{{ValueChangeHandler}} is called when the ```DatePicker``` is hidden which led to nested invocation and related error. When the "date" value is changed the ```DatePicker``` container (Panel) is cleared and re-constructed. The clearance led to the ```DatePicker``` being hidden and the {{ValueChangeHandler}} being invoked.. which led to an attempt to clear the panel, hiding the ```DatePicker``` etc. 

Use of ```ChangeDateHandler``` does not suffer the same nested invocation.