### PR TITLE
GUVNOR-2695: Guided Decision Tables: Default column values not applied for newly added rows - part 2

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -70,8 +70,8 @@ import org.drools.workbench.screens.guided.dtable.client.GuidedDecisionTable;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.Clipboard;
 import org.drools.workbench.screens.guided.dtable.client.editor.clipboard.impl.DefaultClipboard;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
-import org.drools.workbench.screens.guided.dtable.client.widget.analysis.controller.AnalyzerController;
 import org.drools.workbench.screens.guided.dtable.client.widget.analysis.DecisionTableAnalyzerProvider;
+import org.drools.workbench.screens.guided.dtable.client.widget.analysis.controller.AnalyzerController;
 import org.drools.workbench.screens.guided.dtable.client.widget.auditlog.AuditLog;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.columns.BooleanUiColumn;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableColumnSelectedEvent;
@@ -723,12 +723,14 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
         final Map<String, String> convertedDropDownData = new TreeMap<String, String>();
         for ( int i = 0; i < dropDownItems.length; i++ ) {
             final String dropDownItem = dropDownItems[ i ];
+            String key = dropDownItem;
             String display = dropDownItem;
             if ( dropDownItem.indexOf( '=' ) > 0 ) {
                 final String[] split = ConstraintValueHelper.splitValue( dropDownItem );
+                key = split[ 0 ];
                 display = split[ 1 ];
             }
-            convertedDropDownData.put( dropDownItem.trim(),
+            convertedDropDownData.put( key.trim(),
                                        display.trim() );
         }
         return convertedDropDownData;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -504,6 +504,36 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
 
     @Test
     @SuppressWarnings("unchecked")
+    public void getEnumLookupsWithFixedListDefinitionWithSplitter() {
+        final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
+        final Callback<Map<String, String>> callback = mock( Callback.class );
+        final DropDownData dd = DropDownData.create( new String[]{ "1=one", "2=two" } );
+
+        when( oracle.getEnums( eq( "FactType" ),
+                               eq( "field" ),
+                               any( Map.class ) ) ).thenReturn( dd );
+
+        dtPresenter.getEnumLookups( "FactType",
+                                    "field",
+                                    context,
+                                    callback );
+
+        verify( callback,
+                times( 1 ) ).callback( callbackValueCaptor.capture() );
+
+        final Map<String, String> callbackValue = callbackValueCaptor.getValue();
+        assertNotNull( callbackValue );
+        assertFalse( callbackValue.isEmpty() );
+        assertTrue( callbackValue.containsKey( "1" ) );
+        assertTrue( callbackValue.containsKey( "2" ) );
+        assertEquals( "one",
+                      callbackValue.get( "1" ) );
+        assertEquals( "two",
+                      callbackValue.get( "2" ) );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void getEnumLookupsWithQueryExpressionDefinition() {
         final DependentEnumsUtilities.Context context = mock( DependentEnumsUtilities.Context.class );
         final Callback<Map<String, String>> callback = mock( Callback.class );


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2695

The issue was for enumeration definitions containing a splitter between "real value" (used in DRL) and "display value" (used in the UI) the key for the enumeration definition map was incorrectly the whole enumeration definition; and not just the key component.