### PR TITLE
Do not delete GWT unitCache during clean

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -1127,8 +1127,7 @@
                 <include>src/main/webapp/org.drools.workbench.DroolsWorkbench/</include>
                 <include>src/main/webapp/WEB-INF/deploy/</include>
                 <include>src/main/webapp/WEB-INF/classes/</include>
-                <include>src/main/webapp/WEB-INF/lib/</include>
-                <include>**/gwt-unitCache/**</include>
+                <include>src/main/webapp/WEB-INF/lib/</include>                
                 <include>.errai/</include>
                 <include>.niogit/**</include>
               </includes>


### PR DESCRIPTION
@manstis @Rikkola Removing this line from the clean configuration makes SDM startup ~40 seconds faster (once the unitCache is in place):

```Module setup completed in 45802 ms
vs.
Module setup completed in 5721 ms```

@mbarkley and I tested this and we no longer ran into the memory issues, which required the deletion of this directory, that we experienced with earlier versions of GWT 2.8.

Would you guys mind merging this and testing it for a bit in drools-wb before we apply that fix everywhere else?

/cc @porcelli @ederign @psiroky @cristianonicolai 