### PR TITLE
GUVNOR-2735: Guided Decision Table Editor: When opening an empty 'Graph' the editor is not populated

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -206,9 +206,6 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
                               final PlaceRequest placeRequest ) {
         this.editorPath = path;
         this.editorPlaceRequest = placeRequest;
-
-        loadDocument( path,
-                      placeRequest );
     }
 
     protected String getTitleText() {
@@ -242,37 +239,6 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
         modeller.onClose();
     }
 
-    @Override
-    public void loadDocument( final ObservablePath path,
-                              final PlaceRequest placeRequest ) {
-        view.showLoading();
-        service.call( getLoadContentSuccessCallback( path,
-                                                     placeRequest ),
-                      getNoSuchFileExceptionErrorCallback() ).loadContent( path );
-    }
-
-    private RemoteCallback<GuidedDecisionTableEditorContent> getLoadContentSuccessCallback( final ObservablePath path,
-                                                                                            final PlaceRequest placeRequest ) {
-        return ( content ) -> {
-            //Path is set to null when the Editor is closed (which can happen before async calls complete).
-            if ( path == null ) {
-                return;
-            }
-
-            //Add Decision Table to modeller
-            final GuidedDecisionTableView.Presenter dtPresenter = modeller.addDecisionTable( path,
-                                                                                             placeRequest,
-                                                                                             content,
-                                                                                             placeRequest.getParameter( "readOnly", null ) != null,
-                                                                                             null,
-                                                                                             null );
-            registerDocument( dtPresenter );
-            activateDocument( dtPresenter );
-
-            view.hideBusyIndicator();
-        };
-    }
-
     protected void onDecisionTableSelected( final DecisionTableSelectedEvent event ) {
         final GuidedDecisionTableView.Presenter dtPresenter = event.getPresenter();
         if ( dtPresenter == null ) {
@@ -297,8 +263,6 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
                           dtPresenter.getDataModelOracle(),
                           dtPresenter.getModel().getImports(),
                           !dtPresenter.getAccess().isEditable() );
-
-        modeller.activateDecisionTable( dtPresenter );
     }
 
     @Override
@@ -366,7 +330,7 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
                       model );
     }
 
-    void showValidationPopup(final List<ValidationMessage> results ) {
+    void showValidationPopup( final List<ValidationMessage> results ) {
         ValidationPopup.showMessages( results );
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenter.java
@@ -208,15 +208,6 @@ public class GuidedDecisionTableModellerPresenter implements GuidedDecisionTable
     }
 
     @Override
-    public void activateDecisionTable( final GuidedDecisionTableView.Presenter dtPresenter ) {
-        if ( !isDecisionTableAvailable( dtPresenter ) ) {
-            return;
-        }
-        view.activateDecisionTable( dtPresenter.getView() );
-        activeDecisionTable = dtPresenter;
-    }
-
-    @Override
     public void removeDecisionTable( final GuidedDecisionTableView.Presenter dtPresenter ) {
         final Command afterRemovalCommand = () -> {
             view.setEnableColumnCreation( false );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerView.java
@@ -62,8 +62,6 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
 
     void addDecisionTable( final GuidedDecisionTableView gridWidget );
 
-    void activateDecisionTable( final GuidedDecisionTableView gridWidget );
-
     void removeDecisionTable( final GuidedDecisionTableView gridWidget,
                               final Command afterRemovalCommand );
 
@@ -110,8 +108,6 @@ public interface GuidedDecisionTableModellerView extends UberView<GuidedDecision
                                                                 final PlaceRequest placeRequest,
                                                                 final GuidedDecisionTableEditorContent content,
                                                                 final boolean isReadOnly );
-
-        void activateDecisionTable( final GuidedDecisionTableView.Presenter dtPresenter );
 
         void removeDecisionTable( final GuidedDecisionTableView.Presenter dtPresenter );
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerViewImpl.java
@@ -286,6 +286,7 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
     }
 
     private Widget getRuleInheritanceWidget() {
+        ruleSelector.setEnabled( false );
         final HorizontalPanel result = new HorizontalPanel();
         result.add( new Label( GuidedDecisionTableConstants.INSTANCE.AllTheRulesInherit() ) );
         ruleSelector.addValueChangeHandler( new ValueChangeHandler<String>() {
@@ -326,21 +327,6 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
         final double dy = requiredTranslateY - actualTranslateY;
         return new Point2D( dx,
                             dy );
-    }
-
-    @Override
-    public void activateDecisionTable( final GuidedDecisionTableView gridWidget ) {
-        boolean activationChanged = false;
-        for ( GridWidget g : gridLayer.getGridWidgets() ) {
-            final GuidedDecisionTableView dtView = (GuidedDecisionTableView) g;
-            final boolean isActive = gridWidget.equals( dtView );
-            final boolean isAlreadyActive = dtView.isSelected();
-            activationChanged = activationChanged || ( isActive != isAlreadyActive );
-            dtView.activate( isActive );
-        }
-        if ( activationChanged ) {
-            gridLayer.batch();
-        }
     }
 
     @Override
@@ -1013,6 +999,7 @@ public class GuidedDecisionTableModellerViewImpl extends Composite implements Gu
 
     @Override
     public void select( final GridWidget selectedGridWidget ) {
+        ruleSelector.setEnabled( true );
         gridLayer.select( selectedGridWidget );
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableView.java
@@ -58,8 +58,6 @@ import org.uberfire.mvp.PlaceRequest;
 public interface GuidedDecisionTableView extends GridWidget,
                                                  HasBusyIndicator {
 
-    void activate( final boolean isActive );
-
     void setLocation( final double x,
                       final double y );
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableViewImpl.java
@@ -201,21 +201,6 @@ public class GuidedDecisionTableViewImpl extends BaseGridWidget implements Guide
     }
 
     @Override
-    public void activate( final boolean isActive ) {
-        if ( isActive ) {
-            super.select();
-        } else {
-            super.deselect();
-        }
-    }
-
-    @Override
-    public void select() {
-        presenter.select( this );
-        super.select();
-    }
-
-    @Override
     public void newAttributeOrMetaDataColumn() {
         new GuidedDecisionTableAttributeSelectorPopup( presenter.getExistingAttributeNames().toArray( new String[ 0 ] ),
                                                        presenter ).show();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/events/cdi/DecisionTableSelectedEvent.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/events/cdi/DecisionTableSelectedEvent.java
@@ -21,13 +21,25 @@ import org.uberfire.commons.validation.PortablePreconditions;
 public class DecisionTableSelectedEvent {
 
     private final GuidedDecisionTableView.Presenter dtPresenter;
+    private final boolean isLockRequired;
 
     public DecisionTableSelectedEvent( final GuidedDecisionTableView.Presenter dtPresenter ) {
+        this( dtPresenter,
+              true );
+    }
+
+    public DecisionTableSelectedEvent( final GuidedDecisionTableView.Presenter dtPresenter,
+                                       final boolean isLockRequired ) {
         this.dtPresenter = PortablePreconditions.checkNotNull( "dtPresenter", dtPresenter );
+        this.isLockRequired = isLockRequired;
     }
 
     public GuidedDecisionTableView.Presenter getPresenter() {
         return dtPresenter;
+    }
+
+    public boolean isLockRequired() {
+        return isLockRequired;
     }
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -81,6 +81,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
@@ -108,12 +109,16 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                                                eq( null ) );
         verify( presenter,
                 times( 1 ) ).registerDocument( eq( dtPresenter ) );
-        verify( presenter,
-                times( 1 ) ).activateDocument( eq( dtPresenter ) );
-        verify( modeller,
-                times( 1 ) ).activateDecisionTable( eq( dtPresenter ) );
+        verify( decisionTableSelectedEvent,
+                times( 1 ) ).fire( dtSelectedEventCaptor.capture() );
         verify( view,
                 times( 1 ) ).hideBusyIndicator();
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull( dtSelectedEvent );
+        assertNotNull( dtSelectedEvent.getPresenter() );
+        assertEquals( dtPresenter,
+                      dtSelectedEvent.getPresenter() );
     }
 
     @Test
@@ -127,6 +132,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         when( dtPresenter.getOriginalHashCode() ).thenReturn( 0 );
@@ -143,6 +149,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         when( dtPresenter.getOriginalHashCode() ).thenReturn( 10 );
@@ -167,6 +174,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         final DecisionTableSelectedEvent event = new DecisionTableSelectedEvent( dtPresenter );
@@ -186,6 +194,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         final DecisionTableSelectedEvent event = new DecisionTableSelectedEvent( dtPresenter );
@@ -196,13 +205,10 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         presenter.onStartup( path,
                              placeRequest );
 
-        verify( presenter,
-                times( 1 ) ).activateDocument( any( GuidedDecisionTableView.Presenter.class ) );
-
         presenter.onDecisionTableSelected( event );
 
         verify( presenter,
-                times( 2 ) ).activateDocument( any( GuidedDecisionTableView.Presenter.class ) );
+                times( 1 ) ).activateDocument( any( GuidedDecisionTableView.Presenter.class ) );
     }
 
     @Test
@@ -211,6 +217,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         final DecisionTableSelectedEvent event = new DecisionTableSelectedEvent( dtPresenter );
@@ -229,6 +236,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
@@ -239,10 +247,16 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                 times( 1 ) ).showLoading();
         verify( dtService,
                 times( 1 ) ).loadContent( eq( path ) );
-        verify( presenter,
-                times( 1 ) ).activateDocument( eq( dtPresenter ) );
+        verify( decisionTableSelectedEvent,
+                times( 1 ) ).fire( dtSelectedEventCaptor.capture() );
         verify( view,
                 times( 1 ) ).hideBusyIndicator();
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull( dtSelectedEvent );
+        assertNotNull( dtSelectedEvent.getPresenter() );
+        assertEquals( dtPresenter,
+                      dtSelectedEvent.getPresenter() );
 
         when( dtPresenter.getCurrentPath() ).thenReturn( path );
 
@@ -259,7 +273,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
                                                    eq( content ),
                                                    any( Boolean.class ) );
         verify( presenter,
-                times( 2 ) ).activateDocument( eq( dtPresenter ) );
+                times( 1 ) ).activateDocument( eq( dtPresenter ) );
         verify( view,
                 times( 2 ) ).hideBusyIndicator();
     }
@@ -270,6 +284,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
@@ -324,6 +339,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
         final List<ValidationMessage> validationMessages = new ArrayList<ValidationMessage>() {{
@@ -356,6 +372,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
@@ -383,6 +400,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
@@ -412,6 +430,7 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTablePresenterTest.java
@@ -48,9 +48,12 @@ import org.kie.workbench.common.widgets.configresource.client.widget.bound.Impor
 import org.kie.workbench.common.widgets.metadata.client.KieMultipleDocumentEditorWrapperView;
 import org.kie.workbench.common.widgets.metadata.client.menu.RegisteredDocumentsMenuBuilder;
 import org.kie.workbench.common.widgets.metadata.client.widget.OverviewWidgetPresenter;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
@@ -203,6 +206,9 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
     @Mock
     protected PlaceManager placeManager;
 
+    @Captor
+    protected ArgumentCaptor<DecisionTableSelectedEvent> dtSelectedEventCaptor;
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -244,7 +250,8 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
 
     protected abstract P getPresenter();
 
-    protected GuidedDecisionTableView.Presenter makeDecisionTable( final ObservablePath path,
+    protected GuidedDecisionTableView.Presenter makeDecisionTable( final Path originalPath,
+                                                                   final ObservablePath path,
                                                                    final PlaceRequest placeRequest,
                                                                    final GuidedDecisionTableEditorContent content ) {
         final GuidedDecisionTableView.Presenter dtPresenter = mock( GuidedDecisionTableView.Presenter.class );
@@ -259,6 +266,7 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
                                          any( Boolean.class ),
                                          any( Double.class ),
                                          any( Double.class ) ) ).thenReturn( dtPresenter );
+        when( path.getOriginal() ).thenReturn( originalPath );
         when( dtPresenter.getLatestPath() ).thenReturn( path );
         when( dtPresenter.getCurrentPath() ).thenReturn( path );
         when( dtPresenter.getPlaceRequest() ).thenReturn( placeRequest );
@@ -283,9 +291,9 @@ public abstract class BaseGuidedDecisionTablePresenterTest<P extends BaseGuidedD
                 return hashCode;
             }
         };
-        final Overview overview = mock(Overview.class);
-        final Metadata metadata = mock(Metadata.class);
-        when(overview.getMetadata()).thenReturn( metadata );
+        final Overview overview = mock( Overview.class );
+        final Metadata metadata = mock( Metadata.class );
+        when( overview.getMetadata() ).thenReturn( metadata );
         return new GuidedDecisionTableEditorContent( model,
                                                      Collections.<PortableWorkDefinition>emptySet(),
                                                      overview,

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableEditorPresenterTest.java
@@ -19,14 +19,10 @@ package org.drools.workbench.screens.guided.dtable.client.editor;
 import java.util.Collections;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
-import org.drools.workbench.models.datamodel.imports.Import;
-import org.drools.workbench.models.datamodel.imports.Imports;
-import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
+import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
-import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.uberfire.backend.vfs.ObservablePath;
@@ -87,18 +83,26 @@ public class GuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisionTa
     }
 
     @Test
-    public void startUpStartsVerification() {
+    public void startUpSelectsDecisionTable() {
         final ObservablePath path = mock( ObservablePath.class );
         final PlaceRequest placeRequest = mock( PlaceRequest.class );
         final GuidedDecisionTableEditorContent content = makeDecisionTableContent();
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable( path,
+                                                                                 path,
                                                                                  placeRequest,
                                                                                  content );
 
         presenter.onStartup( path,
                              placeRequest );
 
-        verify( dtPresenter ).initialiseAnalysis();
+        verify( decisionTableSelectedEvent,
+                times( 1 ) ).fire( dtSelectedEventCaptor.capture() );
+
+        final DecisionTableSelectedEvent dtSelectedEvent = dtSelectedEventCaptor.getValue();
+        assertNotNull( dtSelectedEvent );
+        assertNotNull( dtSelectedEvent.getPresenter() );
+        assertEquals( dtPresenter,
+                      dtSelectedEvent.getPresenter() );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTableModellerPresenterTest.java
@@ -254,39 +254,6 @@ public class GuidedDecisionTableModellerPresenterTest {
     }
 
     @Test
-    public void activateDecisionTableWhenAvailable() {
-        final ObservablePath path = mock( ObservablePath.class );
-        final PlaceRequest placeRequest = mock( PlaceRequest.class );
-
-        final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent();
-        final GuidedDecisionTableView.Presenter dtPresenter = presenter.addDecisionTable( path,
-                                                                                          placeRequest,
-                                                                                          dtContent,
-                                                                                          false,
-                                                                                          null,
-                                                                                          null );
-        final GuidedDecisionTableView dtView = dtPresenter.getView();
-
-        presenter.activateDecisionTable( dtPresenter );
-
-        verify( view,
-                times( 1 ) ).activateDecisionTable( eq( dtView ) );
-        assertEquals( dtPresenter,
-                      presenter.getActiveDecisionTable() );
-    }
-
-    @Test
-    public void activateDecisionTableWhenNotAvailable() {
-        final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable();
-
-        presenter.activateDecisionTable( dtPresenter );
-
-        verify( view,
-                never() ).activateDecisionTable( any( GuidedDecisionTableView.class ) );
-        assertNull( presenter.getActiveDecisionTable() );
-    }
-
-    @Test
     public void removeDecisionTable() {
         final GuidedDecisionTableView.Presenter dtPresenter = makeDecisionTable();
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -47,7 +47,6 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshAttributesPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshConditionsPanelEvent;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.RefreshMetaDataPanelEvent;
-import org.drools.workbench.screens.guided.dtable.client.widget.table.model.GuidedDecisionTableUiCell;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.utilities.DependentEnumsUtilities;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableLinkManager.LinkFoundCallback;
@@ -171,6 +170,7 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void refreshContent() {
         // dtPresenter.setContent(...) is called by the base tests @Before method so
         // expect some invocations to have occurred twice: once for setContent(...)
@@ -1426,7 +1426,6 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
 
         final ArgumentCaptor<Integer> columnIndexCaptor = ArgumentCaptor.forClass( Integer.class );
         final ArgumentCaptor<GridData.Range> rowRangeCaptor = ArgumentCaptor.forClass( GridData.Range.class );
-        final ArgumentCaptor<GuidedDecisionTableUiCell> cellValueCaptor = ArgumentCaptor.forClass( GuidedDecisionTableUiCell.class );
 
         dtPresenter.onDeleteSelectedCells();
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2735

This PR ensures the "Guided Decision Table Graph Editor" is correctly setup when there are no Decision Tables in the graph. This PR also removes the cumbersome differentiation between "active" and "selected" and ensures the first Decision Table (or singular Decision Table in the "regular" editor) is pre-selected and V&V activated etc.