### PR TITLE
GUVNOR-2739: Guided Decision Table Graph Editor: Add ability to create new Decision Tables from within editor

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenter.java
@@ -17,6 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.editor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,11 +41,13 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDeci
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTablePresenter.Access;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectedEvent;
+import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizardHelper;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphContent;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorGraphModel;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableGraphEditorService;
+import org.guvnor.common.services.project.context.ProjectContext;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.metadata.model.Overview;
 import org.jboss.errai.bus.client.api.messaging.Message;
@@ -98,6 +101,9 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
     private GuidedDecisionTableEditorGraphContent content;
     private LoadGraphLatch loadGraphLatch = null;
     private SaveGraphLatch saveGraphLatch = null;
+
+    private ProjectContext context;
+    private NewGuidedDecisionTableWizardHelper helper;
 
     protected ObservablePath.OnConcurrentUpdateEvent concurrentUpdateSessionInfo = null;
     protected Access access = new Access();
@@ -293,12 +299,14 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                                                     final Event<NotificationEvent> notification,
                                                     final Event<SaveInProgressEvent> saveInProgressEvent,
                                                     final Event<DecisionTableSelectedEvent> decisionTableSelectedEvent,
-                                                    final GuidedDTableGraphResourceType resourceType,
+                                                    final GuidedDTableGraphResourceType dtGraphResourceType,
                                                     final EditMenuBuilder editMenuBuilder,
                                                     final ViewMenuBuilder viewMenuBuilder,
                                                     final InsertMenuBuilder insertMenuBuilder,
                                                     final RadarMenuBuilder radarMenuBuilder,
                                                     final GuidedDecisionTableModellerView.Presenter modeller,
+                                                    final ProjectContext context,
+                                                    final NewGuidedDecisionTableWizardHelper helper,
                                                     final SyncBeanManager beanManager,
                                                     final PlaceManager placeManager,
                                                     final LockManager lockManager ) {
@@ -306,7 +314,7 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                service,
                notification,
                decisionTableSelectedEvent,
-               resourceType,
+               dtGraphResourceType,
                editMenuBuilder,
                viewMenuBuilder,
                insertMenuBuilder,
@@ -316,6 +324,8 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                placeManager );
         this.graphService = graphService;
         this.saveInProgressEvent = saveInProgressEvent;
+        this.context = context;
+        this.helper = helper;
         this.lockManager = lockManager;
     }
 
@@ -336,6 +346,17 @@ public class GuidedDecisionTableGraphEditorPresenter extends BaseGuidedDecisionT
                 removeDocument( dtPresenter );
             }
         } );
+
+        registeredDocumentsMenuBuilder.setNewDocumentCommand( this::onNewDocument );
+    }
+
+    void onNewDocument() {
+        final Path contextPath = context.getActivePackage().getPackageMainResourcesPath();
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             "",
+                                             GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY,
+                                             view,
+                                             ( path ) -> onOpenDocumentsInEditor( Collections.singletonList( path ) ) );
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/handlers/NewGuidedDecisionTableHandler.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/handlers/NewGuidedDecisionTableHandler.java
@@ -25,15 +25,12 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.screens.guided.dtable.client.resources.GuidedDecisionTableResources;
 import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
-import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizard;
+import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizardHelper;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.project.model.Package;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
-import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
-import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
 import org.kie.workbench.common.widgets.client.handlers.DefaultNewResourceHandler;
 import org.kie.workbench.common.widgets.client.handlers.NewResourcePresenter;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
@@ -56,12 +53,8 @@ public class NewGuidedDecisionTableHandler extends DefaultNewResourceHandler {
     private GuidedDTableResourceType resourceType;
     private GuidedDecisionTableOptions options;
     private BusyIndicatorView busyIndicatorView;
-    private AsyncPackageDataModelOracleFactory oracleFactory;
+    private NewGuidedDecisionTableWizardHelper helper;
     private SyncBeanManager iocManager;
-
-    private NewGuidedDecisionTableWizard wizard;
-
-    private AsyncPackageDataModelOracle oracle;
 
     private NewResourcePresenter newResourcePresenter;
 
@@ -75,14 +68,14 @@ public class NewGuidedDecisionTableHandler extends DefaultNewResourceHandler {
                                           final GuidedDTableResourceType resourceType,
                                           final GuidedDecisionTableOptions options,
                                           final BusyIndicatorView busyIndicatorView,
-                                          final AsyncPackageDataModelOracleFactory oracleFactory,
+                                          final NewGuidedDecisionTableWizardHelper helper,
                                           final SyncBeanManager iocManager ) {
         this.placeManager = placeManager;
         this.service = service;
         this.resourceType = resourceType;
         this.options = options;
         this.busyIndicatorView = busyIndicatorView;
-        this.oracleFactory = oracleFactory;
+        this.helper = helper;
         this.iocManager = iocManager;
     }
 
@@ -129,51 +122,13 @@ public class NewGuidedDecisionTableHandler extends DefaultNewResourceHandler {
         final GuidedDecisionTable52 model = new GuidedDecisionTable52();
         model.setTableFormat( tableFormat );
         model.setTableName( baseFileName );
-        save( contextPath,
-              baseFileName,
-              model );
-    }
 
-    private void createDecisionTableWithWizard( final Path contextPath,
-                                                final String baseFileName,
-                                                final GuidedDecisionTable52.TableFormat tableFormat ) {
-        service.call( new RemoteCallback<PackageDataModelOracleBaselinePayload>() {
-
-            @Override
-            public void callback( final PackageDataModelOracleBaselinePayload dataModel ) {
-                newResourcePresenter.complete();
-                oracle = oracleFactory.makeAsyncPackageDataModelOracle( contextPath,
-                                                                        dataModel );
-
-                //This NewResourceHandler is @ApplicationScoped and so has a single instance of the NewGuidedDecisionTableWizard injected.
-                //The Wizard maintains state and hence multiple use of the same Wizard instance leads to the Wizard UI showing stale values.
-                //Rather than have the Wizard initialise fields when shown I elected to create new instances whenever needed.
-                wizard = iocManager.lookupBean( NewGuidedDecisionTableWizard.class ).getInstance();
-
-                wizard.setContent( contextPath,
-                                   baseFileName,
-                                   tableFormat,
-                                   oracle,
-                                   NewGuidedDecisionTableHandler.this );
-                wizard.start();
-            }
-        } ).loadDataModel( contextPath );
-    }
-
-    public void destroyWizard() {
-        if ( wizard != null ) {
-            iocManager.destroyBean( wizard );
-            wizard = null;
-        }
-    }
-
-    public void save( final Path contextPath,
-                      final String baseFileName,
-                      final GuidedDecisionTable52 model ) {
-        destroyWizard();
-        oracleFactory.destroy( oracle );
+        final RemoteCallback<Path> onSaveSuccessCallback = getSuccessCallback( newResourcePresenter );
         busyIndicatorView.showBusyIndicator( CommonConstants.INSTANCE.Saving() );
-        service.call( getSuccessCallback( newResourcePresenter ),
+        service.call( ( Path path ) -> {
+                          busyIndicatorView.hideBusyIndicator();
+                          onSaveSuccessCallback.callback( path );
+                      },
                       new HasBusyIndicatorDefaultErrorCallback( busyIndicatorView ) ).create( contextPath,
                                                                                               buildFileName( baseFileName,
                                                                                                              resourceType ),
@@ -181,18 +136,22 @@ public class NewGuidedDecisionTableHandler extends DefaultNewResourceHandler {
                                                                                               "" );
     }
 
+    private void createDecisionTableWithWizard( final Path contextPath,
+                                                final String baseFileName,
+                                                final GuidedDecisionTable52.TableFormat tableFormat ) {
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             busyIndicatorView,
+                                             getSuccessCallback( newResourcePresenter ) );
+    }
+
     @Override
     protected RemoteCallback<Path> getSuccessCallback( final NewResourcePresenter presenter ) {
-        return new RemoteCallback<Path>() {
-
-            @Override
-            public void callback( final Path path ) {
-                busyIndicatorView.hideBusyIndicator();
-                presenter.complete();
-                notifySuccess();
-                placeManager.goTo( path );
-            }
-
+        return ( Path path ) -> {
+            presenter.complete();
+            notifySuccess();
+            placeManager.goTo( path );
         };
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizard.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizard.java
@@ -78,7 +78,17 @@ public class NewGuidedDecisionTableWizard extends AbstractWizard {
 
     private GuidedDecisionTable52 model;
     private AsyncPackageDataModelOracle oracle;
-    private NewGuidedDecisionTableHandler handler;
+    private GuidedDecisionTableWizardHandler handler;
+
+    public interface GuidedDecisionTableWizardHandler {
+
+        void save( final Path contextPath,
+                   final String baseFileName,
+                   final GuidedDecisionTable52 model );
+
+        void destroyWizard();
+
+    }
 
     @PostConstruct
     public void setupPages() {
@@ -95,7 +105,7 @@ public class NewGuidedDecisionTableWizard extends AbstractWizard {
                             final String baseFileName,
                             final GuidedDecisionTable52.TableFormat tableFormat,
                             final AsyncPackageDataModelOracle oracle,
-                            final NewGuidedDecisionTableHandler handler ) {
+                            final GuidedDecisionTableWizardHandler handler ) {
         this.model = new GuidedDecisionTable52();
         this.model.setTableFormat( tableFormat );
         this.contextPath = contextPath;

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizardHelper.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizardHelper.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.wizard;
+
+import javax.inject.Inject;
+
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
+import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.commons.validation.PortablePreconditions;
+import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
+import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+
+/**
+ * Helps create and save a new Guided Decision Table using the {@link NewGuidedDecisionTableWizard} wizard.
+ * Handles all of the boiler-plate to initialise and manage the Wizard's state together with performing the
+ * creation of any resulting Guided Decision Table. Users of this class need to provide a "Save" success callback.
+ */
+public class NewGuidedDecisionTableWizardHelper {
+
+    private Caller<GuidedDecisionTableEditorService> dtService;
+    private AsyncPackageDataModelOracleFactory oracleFactory;
+    private SyncBeanManager beanManager;
+
+    private NewGuidedDecisionTableWizard wizard;
+
+    private GuidedDTableResourceType dtResourceType = new GuidedDTableResourceType();
+
+    @Inject
+    public NewGuidedDecisionTableWizardHelper( final Caller<GuidedDecisionTableEditorService> dtService,
+                                               final AsyncPackageDataModelOracleFactory oracleFactory,
+                                               final SyncBeanManager beanManager ) {
+        this.dtService = dtService;
+        this.oracleFactory = oracleFactory;
+        this.beanManager = beanManager;
+    }
+
+    /**
+     * Presents the {@link NewGuidedDecisionTableWizard} to Users to creates a new Guided Decision Table.
+     * @param contextPath
+     *         The base path where the Decision Table will be created. Cannot be null.
+     * @param baseFileName
+     *         The base file name of the new Decision Table. Cannot be null.
+     * @param tableFormat
+     *         The format of the Decision Table. Cannot be null.
+     * @param view
+     *         A {@link HasBusyIndicator} to handle status messages. Cannot be null.
+     * @param onSaveSuccessCallback
+     *         Called when the new Decision Table has successfully been created. Cannot be null.
+     */
+    public void createNewGuidedDecisionTable( final Path contextPath,
+                                              final String baseFileName,
+                                              final GuidedDecisionTable52.TableFormat tableFormat,
+                                              final HasBusyIndicator view,
+                                              final RemoteCallback<Path> onSaveSuccessCallback ) {
+        PortablePreconditions.checkNotNull( "contextPath",
+                                            contextPath );
+        PortablePreconditions.checkNotNull( "baseFileName",
+                                            baseFileName );
+        PortablePreconditions.checkNotNull( "tableFormat",
+                                            tableFormat );
+        PortablePreconditions.checkNotNull( "view",
+                                            view );
+        PortablePreconditions.checkNotNull( "onSaveSuccessCallback",
+                                            onSaveSuccessCallback );
+
+        dtService.call( new RemoteCallback<PackageDataModelOracleBaselinePayload>() {
+
+            @Override
+            public void callback( final PackageDataModelOracleBaselinePayload dataModel ) {
+                final AsyncPackageDataModelOracle oracle = oracleFactory.makeAsyncPackageDataModelOracle( contextPath,
+                                                                                                          dataModel );
+
+                //NewGuidedDecisionTableHandler is @ApplicationScoped and so has a single instance of the NewGuidedDecisionTableWizard injected.
+                //The Wizard maintains state and hence multiple use of the same Wizard instance leads to the Wizard UI showing stale values.
+                //Rather than have the Wizard initialise fields when shown I elected to create new instances whenever needed.
+                wizard = beanManager.lookupBean( NewGuidedDecisionTableWizard.class ).getInstance();
+
+                wizard.setContent( contextPath,
+                                   baseFileName,
+                                   tableFormat,
+                                   oracle,
+                                   new NewGuidedDecisionTableWizard.GuidedDecisionTableWizardHandler() {
+
+                                       @Override
+                                       public void save( final Path contextPath,
+                                                         final String baseFileName,
+                                                         final GuidedDecisionTable52 model ) {
+                                           destroyWizard();
+                                           oracleFactory.destroy( oracle );
+                                           view.showBusyIndicator( CommonConstants.INSTANCE.Saving() );
+                                           dtService.call( ( Path path ) -> {
+                                                               view.hideBusyIndicator();
+                                                               onSaveSuccessCallback.callback( path );
+                                                           },
+                                                           new HasBusyIndicatorDefaultErrorCallback( view ) ).create( contextPath,
+                                                                                                                      buildFileName( baseFileName ),
+                                                                                                                      model,
+                                                                                                                      "" );
+
+                                       }
+
+                                       private String buildFileName( final String baseFileName ) {
+                                           final String suffix = dtResourceType.getSuffix();
+                                           final String prefix = dtResourceType.getPrefix();
+                                           final String extension = !( suffix == null || "".equals( suffix ) ) ? "." + dtResourceType.getSuffix() : "";
+                                           if ( baseFileName.endsWith( extension ) ) {
+                                               return prefix + baseFileName;
+                                           }
+                                           return prefix + baseFileName + extension;
+                                       }
+
+                                       @Override
+                                       public void destroyWizard() {
+                                           if ( wizard != null ) {
+                                               beanManager.destroyBean( wizard );
+                                               wizard = null;
+                                           }
+                                       }
+                                   } );
+                wizard.start();
+            }
+        } ).loadDataModel( contextPath );
+    }
+
+}

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/handlers/NewGuidedDecisionTableHandlerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/handlers/NewGuidedDecisionTableHandlerTest.java
@@ -22,6 +22,7 @@ import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTabl
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat;
 import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
 import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizard;
+import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizardHelper;
 import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
 import org.guvnor.common.services.project.model.Package;
 import org.jboss.errai.common.client.api.Caller;
@@ -88,17 +89,21 @@ public class NewGuidedDecisionTableHandlerTest {
     private ArgumentCaptor<String> fileNameCaptor;
 
     private NewGuidedDecisionTableHandler handler;
+    private NewGuidedDecisionTableWizardHelper helper;
     private GuidedDTableResourceType resourceType = new GuidedDTableResourceType();
 
     @Before
     public void setup() {
         serviceCaller = new CallerMock<>( service );
+        helper = new NewGuidedDecisionTableWizardHelper( serviceCaller,
+                                                         oracleFactory,
+                                                         beanManager );
         final NewGuidedDecisionTableHandler wrapped = new NewGuidedDecisionTableHandler( placeManager,
                                                                                          serviceCaller,
                                                                                          resourceType,
                                                                                          options,
                                                                                          busyIndicatorView,
-                                                                                         oracleFactory,
+                                                                                         helper,
                                                                                          beanManager ) {
             {
                 this.notificationEvent = mockNotificationEvent;
@@ -141,7 +146,7 @@ public class NewGuidedDecisionTableHandlerTest {
                                          fileNameCaptor.capture(),
                                          eq( TableFormat.EXTENDED_ENTRY ),
                                          any( AsyncPackageDataModelOracle.class ),
-                                         eq( handler ) );
+                                         any( NewGuidedDecisionTableWizard.GuidedDecisionTableWizardHandler.class ) );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizardHelperTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/wizard/NewGuidedDecisionTableWizardHelperTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.guided.dtable.client.wizard;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.screens.guided.dtable.client.type.GuidedDTableResourceType;
+import org.drools.workbench.screens.guided.dtable.client.wizard.NewGuidedDecisionTableWizard.GuidedDecisionTableWizardHandler;
+import org.drools.workbench.screens.guided.dtable.service.GuidedDecisionTableEditorService;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracle;
+import org.kie.workbench.common.widgets.client.datamodel.AsyncPackageDataModelOracleFactory;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class NewGuidedDecisionTableWizardHelperTest {
+
+    @Mock
+    private GuidedDecisionTableEditorService dtService;
+    private Caller<GuidedDecisionTableEditorService> dtServiceCaller;
+
+    @Mock
+    private AsyncPackageDataModelOracleFactory oracleFactory;
+
+    @Mock
+    private PackageDataModelOracleBaselinePayload oracleBasePayload;
+
+    @Mock
+    private AsyncPackageDataModelOracle oracle;
+
+    @Mock
+    private SyncBeanManager beanManager;
+
+    @Mock
+    private SyncBeanDef<NewGuidedDecisionTableWizard> wizardBeanDef;
+
+    @Mock
+    private NewGuidedDecisionTableWizard wizardBean;
+
+    @Mock
+    private Path contextPath;
+
+    private String baseFileName = "baseFileName";
+
+    private GuidedDecisionTable52.TableFormat tableFormat = GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY;
+
+    @Mock
+    private HasBusyIndicator view;
+
+    @Mock
+    private RemoteCallback<Path> onSaveSuccessCallback;
+
+    @Captor
+    private ArgumentCaptor<GuidedDecisionTableWizardHandler> wizardHandlerCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> fileNameCaptor;
+
+    @Rule
+    public ExpectedException rule = ExpectedException.none();
+
+    private GuidedDecisionTable52 model;
+
+    private NewGuidedDecisionTableWizardHelper helper;
+
+    private GuidedDTableResourceType dtResourceType = new GuidedDTableResourceType();
+
+    @Before
+    public void setup() {
+        dtServiceCaller = new CallerMock<>( dtService );
+        model = new GuidedDecisionTable52();
+        model.setTableFormat( tableFormat );
+
+        helper = new NewGuidedDecisionTableWizardHelper( dtServiceCaller,
+                                                         oracleFactory,
+                                                         beanManager );
+
+        when( beanManager.lookupBean( eq( NewGuidedDecisionTableWizard.class ) ) ).thenReturn( wizardBeanDef );
+        when( wizardBeanDef.getInstance() ).thenReturn( wizardBean );
+
+        when( dtService.loadDataModel( eq( contextPath ) ) ).thenReturn( oracleBasePayload );
+
+        when( dtService.create( any( Path.class ),
+                                any( String.class ),
+                                any( GuidedDecisionTable52.class ),
+                                any( String.class ) ) ).<Path>thenAnswer( ( invocation ) -> {
+            final Path path = ( (Path) invocation.getArguments()[ 0 ] );
+            final String fileName = ( (String) invocation.getArguments()[ 1 ] );
+            final Path newPath = PathFactory.newPath( fileName,
+                                                      path.toURI() + "/" + fileName );
+            return newPath;
+        } );
+
+        when( oracleFactory.makeAsyncPackageDataModelOracle( contextPath,
+                                                             oracleBasePayload ) ).thenReturn( oracle );
+    }
+
+    @Test
+    public void checkNullContextPath() {
+        rule.expect( IllegalArgumentException.class );
+
+        helper.createNewGuidedDecisionTable( null,
+                                             baseFileName,
+                                             tableFormat,
+                                             view,
+                                             onSaveSuccessCallback );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkNullBaseFilename() {
+        rule.expect( IllegalArgumentException.class );
+
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             null,
+                                             tableFormat,
+                                             view,
+                                             onSaveSuccessCallback );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkNullTableFormat() {
+        rule.expect( IllegalArgumentException.class );
+
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             null,
+                                             view,
+                                             onSaveSuccessCallback );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkNullHasBusyIndicator() {
+        rule.expect( IllegalArgumentException.class );
+
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             null,
+                                             onSaveSuccessCallback );
+    }
+
+    @Test
+    public void checkNullSaveSuccessCallback() {
+        rule.expect( IllegalArgumentException.class );
+
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             view,
+                                             null );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkWizardContentIsSet() {
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             view,
+                                             onSaveSuccessCallback );
+
+        verify( wizardBean,
+                times( 1 ) ).setContent( eq( contextPath ),
+                                         eq( baseFileName ),
+                                         eq( tableFormat ),
+                                         eq( oracle ),
+                                         any( GuidedDecisionTableWizardHandler.class ) );
+    }
+
+    @Test
+    public void checkWizardHandlerSave() {
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             view,
+                                             onSaveSuccessCallback );
+
+        verify( wizardBean,
+                times( 1 ) ).setContent( eq( contextPath ),
+                                         eq( baseFileName ),
+                                         eq( tableFormat ),
+                                         eq( oracle ),
+                                         wizardHandlerCaptor.capture() );
+
+        final GuidedDecisionTableWizardHandler wizardHandler = wizardHandlerCaptor.getValue();
+        assertNotNull( wizardHandler );
+
+        wizardHandler.save( contextPath,
+                            baseFileName,
+                            model );
+
+        verify( beanManager,
+                times( 1 ) ).destroyBean( wizardBean );
+        verify( oracleFactory,
+                times( 1 ) ).destroy( oracle );
+        verify( view,
+                times( 1 ) ).showBusyIndicator( any( String.class ) );
+        verify( dtService,
+                times( 1 ) ).create( eq( contextPath ),
+                                     fileNameCaptor.capture(),
+                                     eq( model ),
+                                     eq( "" ) );
+        verify( onSaveSuccessCallback,
+                times( 1 ) ).callback( any( Path.class ) );
+        verify( view,
+                times( 1 ) ).hideBusyIndicator();
+
+        final String fileName = fileNameCaptor.getValue();
+        assertNotNull( fileName );
+        assertEquals( baseFileName + "." + dtResourceType.getSuffix(),
+                      fileName );
+    }
+
+    @Test
+    public void checkWizardHandlerDestroyWizard() {
+        helper.createNewGuidedDecisionTable( contextPath,
+                                             baseFileName,
+                                             tableFormat,
+                                             view,
+                                             onSaveSuccessCallback );
+
+        verify( wizardBean,
+                times( 1 ) ).setContent( eq( contextPath ),
+                                         eq( baseFileName ),
+                                         eq( tableFormat ),
+                                         eq( oracle ),
+                                         wizardHandlerCaptor.capture() );
+
+        final GuidedDecisionTableWizardHandler wizardHandler = wizardHandlerCaptor.getValue();
+        assertNotNull( wizardHandler );
+
+        wizardHandler.destroyWizard();
+
+        verify( beanManager,
+                times( 1 ) ).destroyBean( wizardBean );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2739

This PR adds the ability to create new Decision Tables whilst editing a graph.

It refactors use of the Decision Table Wizard so it's more easily reusable from both the ```NewGuidedDecisionTableHandler``` and ```GuidedDecisionTableGraphEditorPresenter```.