### PR TITLE
GUVNOR-2755: Guided Decision Table Editor: View Menu zoom level does not reset to 100% when re-opening Editor

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenu.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/CellContextMenu.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 
 import java.util.List;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -29,7 +29,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-@ApplicationScoped
+@Dependent
 public class CellContextMenu extends BaseMenu implements IsWidget,
                                                          CellContextMenuView.Presenter {
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/EditMenuBuilder.java
@@ -18,7 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 
 import java.util.List;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -37,7 +37,7 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
-@ApplicationScoped
+@Dependent
 public class EditMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuBuilder,
                                                          EditMenuView.Presenter {
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/InsertMenuBuilder.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -33,7 +33,7 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
-@ApplicationScoped
+@Dependent
 public class InsertMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuBuilder,
                                                            InsertMenuView.Presenter {
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RadarMenuBuilder.java
@@ -17,7 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -29,7 +29,7 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
-@ApplicationScoped
+@Dependent
 public class RadarMenuBuilder implements MenuFactory.CustomMenuBuilder,
                                          RadarMenuView.Presenter {
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenu.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/RowContextMenu.java
@@ -20,7 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -31,7 +31,7 @@ import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi
 import org.drools.workbench.screens.guided.dtable.client.widget.table.events.cdi.DecisionTableSelectionsChangedEvent;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-@ApplicationScoped
+@Dependent
 public class RowContextMenu extends BaseMenu implements IsWidget,
                                                         RowContextMenuView.Presenter {
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilder.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/menu/ViewMenuBuilder.java
@@ -17,7 +17,7 @@
 package org.drools.workbench.screens.guided.dtable.client.editor.menu;
 
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -29,7 +29,7 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
 
-@ApplicationScoped
+@Dependent
 public class ViewMenuBuilder extends BaseMenu implements MenuFactory.CustomMenuBuilder,
                                                          ViewMenuView.Presenter {
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2755

Moving to ```@Dependent``` scoped beans not only ensures the menus are correctly re-initialised but also means they work as expected when multiple Editor instances are open. Win, win!