### PR TITLE
GUVNOR-2758: Collapse Empty Rules warnings into one line

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/AnalysisReportScreen.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/AnalysisReportScreen.java
@@ -115,11 +115,7 @@ public class AnalysisReportScreen {
     }
 
     private ArrayList<Issue> getIssues( final AnalysisReport report ) {
-        final IssuesSet issues = new IssuesSet();
-        for ( final Issue issue : report.getAnalysisData() ) {
-            issues.add( issue );
-        }
-        return new ArrayList<>( issues );
+        return new ArrayList<>( new IssuesSet( report.getAnalysisData() ) );
     }
 
     @DefaultPosition

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/AnalysisReportScreenTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/AnalysisReportScreenTest.java
@@ -122,6 +122,50 @@ public class AnalysisReportScreenTest {
     }
 
     @Test
+    public void testMergeEmptyRules() throws
+            Exception {
+        testMerge( ExplanationType.EMPTY_RULE );
+
+    }
+
+    @Test
+    public void testMergeMissingAction() throws
+            Exception {
+        testMerge( ExplanationType.MISSING_ACTION );
+
+    }
+
+    @Test
+    public void testMergeMissingRestriction() throws
+            Exception {
+        testMerge( ExplanationType.MISSING_RESTRICTION );
+
+    }
+
+    private void testMerge( ExplanationType type ) {
+        Issue issue1 = new Issue( Severity.WARNING,
+                type,
+                new HashSet<>( Arrays.asList( 1 ) ) );
+
+        Issue issue2 = new Issue( Severity.WARNING,
+                type,
+                new HashSet<>( Arrays.asList( 2 ) ) );
+        screen.showReport( getAnalysis( issue1, issue2 ) );
+
+        verify( placeManager ).goTo( eq( "org.drools.workbench.AnalysisReportScreen" ) );
+
+        assertEquals( 1, dataProvider.getList().size() );
+
+        Issue issue = (Issue) dataProvider.getList().get(0);
+
+        assertEquals( Severity.WARNING, issue.getSeverity() );
+        assertEquals( type, issue.getExplanationType() );
+        assertEquals( new HashSet<>( Arrays.asList( 1, 2 ) ), issue.getRowNumbers() );
+
+        verify( view ).showIssue( issue );
+    }
+
+    @Test
     public void testDoNotShowIfThereAreNoIssues() throws
                                                   Exception {
         screen.showReport( getAnalysis() );

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectEmptyRowCheck.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/checks/DetectEmptyRowCheck.java
@@ -16,15 +16,11 @@
 
 package org.drools.workbench.services.verifier.core.checks;
 
-import com.google.gwt.safehtml.shared.SafeHtml;
 import org.drools.workbench.services.verifier.core.cache.inspectors.RuleInspector;
 import org.drools.workbench.services.verifier.core.checks.base.SingleCheck;
-import org.drools.workbench.services.verifier.api.client.reporting.Explanation;
 import org.drools.workbench.services.verifier.api.client.reporting.ExplanationType;
-import org.drools.workbench.services.verifier.api.client.reporting.ExplanationProvider;
 import org.drools.workbench.services.verifier.api.client.reporting.Issue;
 import org.drools.workbench.services.verifier.api.client.reporting.Severity;
-import org.drools.workbench.services.verifier.api.client.resources.i18n.AnalysisConstants;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -41,13 +37,14 @@ public class DetectEmptyRowCheck
         hasIssues = false;
 
         hasIssues = !ruleInspector.atLeastOneConditionHasAValue() && !ruleInspector.atLeastOneActionHasAValue();
+
     }
 
     @Override
     public Issue getIssue() {
         Issue issue = new Issue( Severity.WARNING,
                                  ExplanationType.EMPTY_RULE,
-                                 new HashSet<Integer>( Arrays.asList( ruleInspector.getRowIndex() + 1 ) ) );
+                                 new HashSet<>( Arrays.asList( ruleInspector.getRowIndex() + 1 ) ) );
 
         return issue;
     }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-web-worker/src/test/java/org/drools/workbench/verifier/webworker/client/DecisionTableAnalyzerTest.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-web-worker/src/test/java/org/drools/workbench/verifier/webworker/client/DecisionTableAnalyzerTest.java
@@ -23,6 +23,7 @@ import org.drools.workbench.models.datamodel.imports.Import;
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
+import org.drools.workbench.services.verifier.api.client.resources.i18n.AnalysisConstants;
 import org.drools.workbench.verifier.webworker.client.testutil.ExtendedGuidedDecisionTableBuilder;
 import org.drools.workbench.verifier.webworker.client.testutil.LimitedGuidedDecisionTableBuilder;
 import org.junit.Test;
@@ -61,6 +62,27 @@ public class DecisionTableAnalyzerTest
     }
 
     @Test
+    public void testMultipleEmptyRows() throws Exception {
+        table52 = new ExtendedGuidedDecisionTableBuilder( "org.test",
+                new ArrayList<Import>(),
+                "mytable" )
+                .withConditionIntegerColumn( "a", "Person", "age", "==" )
+                .withData( new Object[][]{ { 1, "description", "" },
+                                           { 2, "description", "" }
+                                         } )
+                .buildTable();
+
+        fireUpAnalyzer();
+
+        assertEquals( 4, analyzerProvider.getAnalysisReport().size() );
+        assertContains( AnalysisConstants.INSTANCE.EmptyRule(), analyzerProvider.getAnalysisReport(), 1 );
+        assertContains( AnalysisConstants.INSTANCE.EmptyRule(), analyzerProvider.getAnalysisReport(), 2 );
+        assertOnlyContains( analyzerProvider.getAnalysisReport(),
+                            AnalysisConstants.INSTANCE.EmptyRule(),
+                            AnalysisConstants.INSTANCE.SingleHitLost() );
+    }
+
+    @Test
     public void testRuleHasNoAction() throws Exception {
         table52 = new ExtendedGuidedDecisionTableBuilder( "org.test",
                                                           new ArrayList<Import>(),
@@ -72,6 +94,23 @@ public class DecisionTableAnalyzerTest
         fireUpAnalyzer();
 
         assertContains( "RuleHasNoAction", analyzerProvider.getAnalysisReport() );
+
+    }
+
+    @Test
+    public void testMultipleRuleHasNoActions() throws Exception {
+        table52 = new ExtendedGuidedDecisionTableBuilder( "org.test",
+                new ArrayList<Import>(),
+                "mytable" )
+                .withConditionIntegerColumn( "a", "Person", "age", ">" )
+                .withData( new Object[][]{ { 1, "description", 0 },
+                                           { 2, "description", 1 } } )
+                .buildTable();
+
+        fireUpAnalyzer();
+
+        assertContains( AnalysisConstants.INSTANCE.RuleHasNoAction(), analyzerProvider.getAnalysisReport(), 1 );
+        assertContains( AnalysisConstants.INSTANCE.RuleHasNoAction(), analyzerProvider.getAnalysisReport(), 2 );
 
     }
 


### PR DESCRIPTION
This PR tries to minimize amount of warnings in Analysis Report panel by collapsing Empty Rule warnings into single line.