### PR TITLE
GUVNOR-2777: Remove allRuleInspectors method

### DIFF
--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/RuleInspectorCache.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/cache/RuleInspectorCache.java
@@ -192,10 +192,6 @@ public class RuleInspectorCache {
         return ruleInspectors.get( getRule( (int) row ) );
     }
 
-    public Collection<RuleInspector> allRuleInspectors() {
-        return ruleInspectors.values();
-    }
-
     public AnalyzerConfiguration getConfiguration() {
         return configuration;
     }

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Analyzer.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-core/src/main/java/org/drools/workbench/services/verifier/core/main/Analyzer.java
@@ -80,7 +80,7 @@ public class Analyzer {
 
         final Set<Issue> unorderedIssues = new HashSet<>();
 
-        for ( final RuleInspector ruleInspector : cache.allRuleInspectors() ) {
+        for ( final RuleInspector ruleInspector : cache.all() ) {
             for ( final Check check : ruleInspector.getChecks() ) {
                 if ( check.hasIssues() ) {
                     unorderedIssues.add( check.getIssue() );


### PR DESCRIPTION
The method `allRuleInspectors` was identical with the `all` method and thus it is removed. Just wait if the project compiles without errors.