### PR TITLE
GUVNOR-2778: Display Issue without ExplanationType

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/IssuePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/IssuePresenter.java
@@ -42,11 +42,7 @@ public class IssuePresenter
 
     public void show( final Issue issue ) {
         final String title = ExplanationProvider.toTitle( issue );
-        if ( title == null ) {
-            view.setIssueTitle( title );
-        } else {
-            view.setIssueTitle( title );
-        }
+        view.setIssueTitle( title );
         view.setExplanation( ExplanationProvider.toHTML( issue ) );
         view.setLines( makeRowNumbers( issue ) );
     }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/IssuePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/analysis/panel/IssuePresenterTest.java
@@ -69,6 +69,21 @@ public class IssuePresenterTest {
     }
 
     @Test
+    public void testShowEmptyIssue() throws
+            Exception {
+
+        screen.show( Issue.EMPTY );
+
+        verify( view ).setIssueTitle( "---" );
+        ArgumentCaptor<SafeHtml> safeHtmlArgumentCaptor = ArgumentCaptor.forClass( SafeHtml.class );
+        verify( view ).setExplanation( safeHtmlArgumentCaptor.capture() );
+        assertEquals( "---",
+                safeHtmlArgumentCaptor.getValue()
+                        .asString() );
+        verify( view ).setLines( "" );
+    }
+
+    @Test
     public void testClear() throws
                             Exception {
         screen.clear();

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ExplanationProvider.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/ExplanationProvider.java
@@ -22,6 +22,15 @@ import org.drools.workbench.services.verifier.api.client.resources.i18n.Analysis
 public class ExplanationProvider {
 
     public static SafeHtml toHTML( final Issue issue ) {
+        if ( issue == Issue.EMPTY ) {
+            return new SafeHtml() {
+                @Override
+                public String asString() {
+                    return "---";
+                }
+            };
+        }
+
         switch ( issue.getExplanationType() ) {
             case CONFLICTING_ROWS:
                 return new Explanation()
@@ -169,6 +178,10 @@ public class ExplanationProvider {
     }
 
     public static String toTitle( final Issue issue ) {
+        if ( issue == Issue.EMPTY ) {
+            return "---";
+        }
+
         switch ( issue.getExplanationType() ) {
             case CONFLICTING_ROWS:
                 return AnalysisConstants.INSTANCE.ConflictingRows();
@@ -198,7 +211,7 @@ public class ExplanationProvider {
             case MISSING_RANGE:
                 return AnalysisConstants.INSTANCE.MissingRangeTitle();
             case SINGLE_HIT_LOST:
-                return                        AnalysisConstants.INSTANCE.SingleHitLost();
+                return AnalysisConstants.INSTANCE.SingleHitLost();
             case EMPTY_RULE:
                 return AnalysisConstants.INSTANCE.EmptyRule();
             default:

--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issue.java
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-api/src/main/java/org/drools/workbench/services/verifier/api/client/reporting/Issue.java
@@ -32,7 +32,7 @@ public class Issue {
     private ExplanationType explanationType;
     private String debugMessage;
 
-    public Issue() {
+    private Issue() {
         severity=null;
         rowNumbers=new HashSet<>();
     }


### PR DESCRIPTION
This PR prevents user from creating `Issue` instances without `ExplnationType`. The only `Issue` without `ExplanationType` is now the static instance `Issue.EMPTY`. As a result of this the `IssuePresenter` was simplified.