### PR TITLE
GUVNOR-2783: [Guided Decision Table] Exception thrown during handling Boolean cells

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizer.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/BaseSynchronizer.java
@@ -227,8 +227,10 @@ public abstract class BaseSynchronizer<A extends Synchronizer.MetaData, U extend
         } else if ( dataType == DataType.DataTypes.BOOLEAN ) {
             if ( defaultValue == null ) {
                 dcv = new DTCellValue52( false );
+            } else if ( defaultValue.getBooleanValue() == null ) {
+                dcv = new DTCellValue52( false );
             } else {
-                dcv = new DTCellValue52( defaultValue );
+                dcv = new DTCellValue52( defaultValue.getBooleanValue() );
             }
 
         } else {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/model/synchronizers/impl/ModelSynchronizerTest.java
@@ -16,9 +16,13 @@
 
 package org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.impl;
 
+import org.drools.workbench.models.guided.dtable.shared.model.AttributeCol52;
+import org.drools.workbench.models.guided.dtable.shared.model.DTCellValue52;
+import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.model.synchronizers.ModelSynchronizer;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.junit.Assert.*;
 
@@ -58,6 +62,46 @@ public class ModelSynchronizerTest extends BaseSynchronizerTest {
         assertNull( model.getData().get( 0 ).get( 1 ).getStringValue() );
         assertNull( uiModel.getCell( 0,
                                      1 ) );
+    }
+
+    @Test
+    public void testInitialisationOfBooleanCellsWithDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
+        setupBooleanColumn( ( c ) -> c.setDefaultValue( new DTCellValue52( true ) ) );
+
+        modelSynchronizer.appendRow();
+
+        assertTrue( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertTrue( (Boolean) uiModel.getCell( 0,
+                                               2 ).getValue().getValue() );
+    }
+
+    @Test
+    public void testInitialisationOfBooleanCellsWithNullDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
+        setupBooleanColumn( ( c ) -> c.setDefaultValue( new DTCellValue52( (Boolean) null ) ) );
+
+        modelSynchronizer.appendRow();
+
+        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertFalse( (Boolean) uiModel.getCell( 0,
+                                                2 ).getValue().getValue() );
+    }
+
+    @Test
+    public void testInitialisationOfBooleanCellsWithoutDefaultValue() throws ModelSynchronizer.MoveColumnVetoException {
+        setupBooleanColumn( ( c ) -> {/*Nothing*/ } );
+
+        modelSynchronizer.appendRow();
+
+        assertFalse( model.getData().get( 0 ).get( 2 ).getBooleanValue() );
+        assertFalse( (Boolean) uiModel.getCell( 0,
+                                                2 ).getValue().getValue() );
+    }
+
+    private void setupBooleanColumn( final ParameterizedCommand<AttributeCol52> cmdInit ) throws ModelSynchronizer.MoveColumnVetoException {
+        final AttributeCol52 booleanColumn = new AttributeCol52();
+        booleanColumn.setAttribute( GuidedDecisionTable52.ENABLED_ATTR );
+        cmdInit.execute( booleanColumn );
+        modelSynchronizer.appendColumn( booleanColumn );
     }
 
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2783

New columns can have the default value for ```boolean``` cells set to ```null```

@karreiro Could you please bare this in mind with the changes you are making for column definition? 

A ```boolean``` column should not really permit ```null``` default values; only ```true``` or ```false``` (unless, or until, we support tri-state ```boolean``` fields, ```null```, ```true``` and ```false``` - but it's unsupported atm).