### PR TITLE
GUVNOR-2784: [Guided Decision Table] Changes in individual decision tables doesn't reflect into guided decision table graph

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableEditorService.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-api/src/main/java/org/drools/workbench/screens/guided/dtable/service/GuidedDecisionTableEditorService.java
@@ -19,6 +19,7 @@ package org.drools.workbench.screens.guided.dtable.service;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.screens.guided.dtable.model.GuidedDecisionTableEditorContent;
 import org.guvnor.common.services.shared.file.SupportsUpdate;
+import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.common.services.shared.validation.ValidationService;
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.kie.workbench.common.services.datamodel.model.PackageDataModelOracleBaselinePayload;
@@ -47,5 +48,10 @@ public interface GuidedDecisionTableEditorService
     GuidedDecisionTableEditorContent loadContent( final Path path );
 
     PackageDataModelOracleBaselinePayload loadDataModel( final Path path );
+
+    Path saveAndUpdateGraphEntries( final Path resource,
+                                    final GuidedDecisionTable52 model,
+                                    final Metadata metadata,
+                                    final String comment );
 
 }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenter.java
@@ -343,10 +343,10 @@ public abstract class BaseGuidedDecisionTableEditorPresenter extends KieMultiple
 
         service.call( getSaveSuccessCallback( dtPresenter,
                                               model.hashCode() ),
-                      new HasBusyIndicatorDefaultErrorCallback( view ) ).save( path,
-                                                                               model,
-                                                                               metadata,
-                                                                               commitMessage );
+                      new HasBusyIndicatorDefaultErrorCallback( view ) ).saveAndUpdateGraphEntries( path,
+                                                                                                    model,
+                                                                                                    metadata,
+                                                                                                    commitMessage );
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/BaseGuidedDecisionTableEditorPresenterTest.java
@@ -411,10 +411,10 @@ public class BaseGuidedDecisionTableEditorPresenterTest extends BaseGuidedDecisi
         final ArgumentCaptor<Metadata> metadataCaptor = ArgumentCaptor.forClass( Metadata.class );
 
         verify( dtService,
-                times( 1 ) ).save( eq( path ),
-                                   modelCaptor.capture(),
-                                   metadataCaptor.capture(),
-                                   eq( commitMessage ) );
+                times( 1 ) ).saveAndUpdateGraphEntries( eq( path ),
+                                                        modelCaptor.capture(),
+                                                        metadataCaptor.capture(),
+                                                        eq( commitMessage ) );
         assertNotNull( modelCaptor.getValue() );
         assertEquals( dtPresenter.getModel(),
                       modelCaptor.getValue() );


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2784

The issue was that the links in a graph point to versions of the tables; to support opening "old" versions of the graph (that should then show the older versions of the tables). However when updating a single table (not a graph) the links in the graph file still point to the original versions. This PR updates the graphs' links when a single table is saved.