### PR TITLE
GUVNOR-2814: Guided Decision Table Graph: User is always prompted to save or discard data

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenter.java
@@ -478,6 +478,7 @@ public class GuidedDecisionTablePresenter implements GuidedDecisionTableView.Pre
             initialiseRow( modelColumns,
                            row );
         }
+        setOriginalHashCode( model.hashCode() );
     }
 
     //Ensure field data-type is set (field did not exist before 5.2)

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/editor/GuidedDecisionTableGraphEditorPresenterTest.java
@@ -84,6 +84,9 @@ import static org.mockito.Mockito.*;
 @RunWith(GwtMockitoTestRunner.class)
 public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecisionTablePresenterTest<GuidedDecisionTableGraphEditorPresenter> {
 
+    private static final int INITIAL_HASH_CODE = 100;
+    private static final int EDITOR_HASH_CODE = 200;
+
     @Mock
     private LockManager lockManager;
 
@@ -319,7 +322,7 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
     public void checkOnStartupBasicInitialisation() {
         final ObservablePath dtGraphPath = mock( ObservablePath.class );
         final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( INITIAL_HASH_CODE );
 
         when( dtGraphPath.toURI() ).thenReturn( "dtGraphPath" );
         when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
@@ -333,6 +336,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
                       presenter.editorPath );
         assertEquals( dtGraphPlaceRequest,
                       presenter.editorPlaceRequest );
+        assertEquals( INITIAL_HASH_CODE,
+                      (int) presenter.originalGraphHash );
 
         verify( presenter,
                 times( 1 ) ).initialiseEditor( eq( dtGraphPath ),
@@ -358,7 +363,7 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
     public void checkOnStartupLoadGraphEntries() {
         final ObservablePath dtGraphPath = mock( ObservablePath.class );
         final PlaceRequest dtGraphPlaceRequest = mock( PlaceRequest.class );
-        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent();
+        final GuidedDecisionTableEditorGraphContent dtGraphContent = makeDecisionTableGraphContent( INITIAL_HASH_CODE );
 
         final Path dtPath = mock( Path.class );
         final GuidedDecisionTableEditorContent dtContent = makeDecisionTableContent();
@@ -377,6 +382,9 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
         when( dtService.loadContent( eq( dtPath ) ) ).thenReturn( dtContent );
         when( dtGraphService.loadContent( eq( dtGraphPath ) ) ).thenReturn( dtGraphContent );
         when( versionRecordManager.getCurrentPath() ).thenReturn( dtGraphPath );
+
+        //Fake building of Graph Model from Editor to control hashCode
+        doReturn( makeDecisionTableGraphContent( EDITOR_HASH_CODE ).getModel() ).when( presenter ).buildModelFromEditor();
 
         when( modeller.addDecisionTable( any( ObservablePath.class ),
                                          any( PlaceRequest.class ),
@@ -410,6 +418,8 @@ public class GuidedDecisionTableGraphEditorPresenterTest extends BaseGuidedDecis
                       dtObservablePath.toURI() );
         assertEquals( dtPath.toURI(),
                       dtPathPlaceRequest.getPath().toURI() );
+        assertEquals( EDITOR_HASH_CODE,
+                      (int) presenter.originalGraphHash );
 
         verify( presenter,
                 times( 1 ) ).registerDocument( eq( dtPresenter ) );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/table/GuidedDecisionTablePresenterTest.java
@@ -223,6 +223,9 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
         assertEquals( GuidedDecisionTableView.ROW_HEIGHT,
                       dtPresenter.getUiModel().getRow( 2 ).getHeight(),
                       0.0 );
+
+        assertEquals( dtContent.getModel().hashCode(),
+                      (int) dtPresenter.getOriginalHashCode() );
     }
 
     @Test
@@ -259,6 +262,9 @@ public class GuidedDecisionTablePresenterTest extends BaseGuidedDecisionTablePre
                 times( 2 ) ).initialiseValidationAndVerification();
         verify( dtPresenter,
                 times( 2 ) ).initialiseAuditLog();
+
+        assertEquals( dtContent.getModel().hashCode(),
+                      (int) dtPresenter.getOriginalHashCode() );
 
         //These invocations are as a result of the previous Presenter being destroyed
         verify( dtPresenter,


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2814

This PR ensures the "original" ```hashCode``` is correctly set when a graph (or individual table) is loaded. It does however highlight the status of https://issues.jboss.org/browse/GUVNOR-2262 that is related to the JIRA for this PR in that you are no longer prompted when closing a "dirty" guided decision table as the underlying model lacks a ```hashCode``` implementation (other than the default provided by the JVM). 