### PR TITLE
GUVNOR-2820: Enumerations are present even if they were deleted

### DIFF
--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/pom.xml
@@ -64,6 +64,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/DSLInvalidateDMOPackageCacheDeleteHelper.java
+++ b/drools-wb-screens/drools-wb-dsl-text-editor/drools-wb-dsl-text-editor-backend/src/main/java/org/drools/workbench/screens/dsltext/backend/server/DSLInvalidateDMOPackageCacheDeleteHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.dsltext.backend.server;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.dsltext.type.DSLResourceTypeDefinition;
+import org.guvnor.common.services.project.builder.events.InvalidateDMOPackageCacheEvent;
+import org.kie.workbench.common.services.backend.helpers.AbstractInvalidateDMOPackageCacheDeleteHelper;
+
+/**
+ * DeleteHelper for DSLs to invalidate LRUDataModelOracleCache entries when a DSL is deleted.
+ */
+@ApplicationScoped
+public class DSLInvalidateDMOPackageCacheDeleteHelper extends AbstractInvalidateDMOPackageCacheDeleteHelper<DSLResourceTypeDefinition> {
+
+    @Inject
+    public DSLInvalidateDMOPackageCacheDeleteHelper( final DSLResourceTypeDefinition resourceType,
+                                                     final Event<InvalidateDMOPackageCacheEvent> invalidateDMOPackageCache ) {
+        super( resourceType,
+               invalidateDMOPackageCache );
+    }
+
+}

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/pom.xml
@@ -80,6 +80,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/main/java/org/drools/workbench/screens/enums/backend/server/EnumInvalidateDMOPackageCacheDeleteHelper.java
+++ b/drools-wb-screens/drools-wb-enum-editor/drools-wb-enum-editor-backend/src/main/java/org/drools/workbench/screens/enums/backend/server/EnumInvalidateDMOPackageCacheDeleteHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.enums.backend.server;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.enums.type.EnumResourceTypeDefinition;
+import org.guvnor.common.services.project.builder.events.InvalidateDMOPackageCacheEvent;
+import org.kie.workbench.common.services.backend.helpers.AbstractInvalidateDMOPackageCacheDeleteHelper;
+
+/**
+ * DeleteHelper for Enumerations to invalidate LRUDataModelOracleCache entries when an Enumeration is deleted.
+ */
+@ApplicationScoped
+public class EnumInvalidateDMOPackageCacheDeleteHelper extends AbstractInvalidateDMOPackageCacheDeleteHelper<EnumResourceTypeDefinition> {
+
+    @Inject
+    public EnumInvalidateDMOPackageCacheDeleteHelper( final EnumResourceTypeDefinition resourceType,
+                                                      final Event<InvalidateDMOPackageCacheEvent> invalidateDMOPackageCache ) {
+        super( resourceType,
+               invalidateDMOPackageCache );
+    }
+
+}

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/pom.xml
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/pom.xml
@@ -68,6 +68,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>

--- a/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/main/java/org/drools/workbench/screens/globals/backend/server/GlobalsInvalidateDMOPackageCacheDeleteHelper.java
+++ b/drools-wb-screens/drools-wb-globals-editor/drools-wb-globals-editor-backend/src/main/java/org/drools/workbench/screens/globals/backend/server/GlobalsInvalidateDMOPackageCacheDeleteHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.workbench.screens.globals.backend.server;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.drools.workbench.screens.globals.type.GlobalResourceTypeDefinition;
+import org.guvnor.common.services.project.builder.events.InvalidateDMOPackageCacheEvent;
+import org.kie.workbench.common.services.backend.helpers.AbstractInvalidateDMOPackageCacheDeleteHelper;
+
+/**
+ * DeleteHelper for Globals to invalidate LRUDataModelOracleCache entries when a Global is deleted.
+ */
+@ApplicationScoped
+public class GlobalsInvalidateDMOPackageCacheDeleteHelper extends AbstractInvalidateDMOPackageCacheDeleteHelper<GlobalResourceTypeDefinition> {
+
+    @Inject
+    public GlobalsInvalidateDMOPackageCacheDeleteHelper( final GlobalResourceTypeDefinition resourceType,
+                                                         final Event<InvalidateDMOPackageCacheEvent> invalidateDMOPackageCache ) {
+        super( resourceType,
+               invalidateDMOPackageCache );
+    }
+
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2820

This PR raises events to invalidate the ```LRUDataModelOracleCache``` when certain files are deleted. The cache contains Authoring related meta-data for files in the package; namely DSLs, enumerations and Globals.