### PR TITLE
	 [DROOLS-1391] no need to depend on gwt-user 

### DIFF
--- a/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-import/pom.xml
+++ b/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-import/pom.xml
@@ -180,11 +180,7 @@
       <artifactId>zip4j</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Investigate why is gwt-user needed and ideally remove it, see https://issues.jboss.org/browse/DROOLS-1391 -->
-    <dependency>
-      <groupId>com.google.gwt</groupId>
-      <artifactId>gwt-user</artifactId>
-    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
We just need the annotaions on classpath so that WELD can load them.
The gwt-user jar is pretty heavyweight (16MiB) and otherwise not needed.

Depends on https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/347