### PR TITLE
Don't package server marshaller classes in jar.

### DIFF
--- a/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/pom.xml
+++ b/drools-wb-services/drools-wb-verifier/drools-wb-verifier-backend/pom.xml
@@ -91,8 +91,8 @@
 
                     <deploy>${project.build.directory}/gwt-symbols-deploy</deploy>
                     <extraJvmArgs>-Xmx3G -Xms1024m -Xss1M -XX:CompileThreshold=7000
-                        -Derrai.marshalling.server.classOutput=${project.build.outputDirectory}
                         -Derrai.dynamic_validation.enabled=true
+                        -Derrai.marshalling.server.classOutput.enabled=false
                     </extraJvmArgs>
                     <module>org.drools.workbench.services.verifier.webworker.VerifierWebWorker</module>
                     <logLevel>INFO</logLevel>


### PR DESCRIPTION
Removing the generated Errai server marshallers from drools-wb-verifier-backend jar fixes NPEs that several people have experienced after logging into drools-wb in SDM from missing marshaller definitions.

@manstis can you please review this? I'm not exactly sure what drools-wb-verifier-backend does or how to test that it still works.