### PR TITLE
GUVNOR-2865: Add Default Value widget only once

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopup.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopup.java
@@ -268,7 +268,7 @@ public class ConditionPopup {
     public void makeDefaultValueWidget() {
         //Default value
         if ( model.getTableFormat() == TableFormat.EXTENDED_ENTRY ) {
-            view.addDefaultValue();
+            view.addDefaultValueIfNoPresent();
             if ( model.getTableFormat() == TableFormat.LIMITED_ENTRY ) {
                 return;
             }

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupView.java
@@ -461,9 +461,13 @@ public class ConditionPopupView extends FormStylePopup {
                 limitedEntryValueWidgetContainer ).getIndex();
     }
 
-    public void addDefaultValue() {
-        defaultValueWidgetContainerIndex = addAttribute( new StringBuilder( GuidedDecisionTableConstants.INSTANCE.DefaultValue() ).append( GuidedDecisionTableConstants.COLON ).toString(),
-                defaultValueWidgetContainer ).getIndex();
+    public void addDefaultValueIfNoPresent() {
+        if( defaultValueWidgetContainerIndex == -1 ) {
+            defaultValueWidgetContainerIndex = addAttribute( new StringBuilder( GuidedDecisionTableConstants.INSTANCE.DefaultValue() )
+                                                                    .append(GuidedDecisionTableConstants.COLON)
+                                                                    .toString(),
+                                                             defaultValueWidgetContainer ).getIndex();
+        }
     }
 
     @Override

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupTest.java
@@ -195,7 +195,7 @@ public class ConditionPopupTest {
         verify( popup.view, never() ).addLimitedEntryValue();
         verify( popup.view, never() ).setLimitedEntryVisibility( anyBoolean() );
 
-        verify( popup.view ).addDefaultValue();
+        verify( popup.view ).addDefaultValueIfNoPresent();
         verify( popup.view ).setDefaultValueVisibility( false );
         assertEquals( null, popup.getEditingCol().getDefaultValue() );
 
@@ -231,7 +231,7 @@ public class ConditionPopupTest {
         verify( popup.view, never() ).addLimitedEntryValue();
         verify( popup.view, never() ).setLimitedEntryVisibility( anyBoolean() );
 
-        verify( popup.view ).addDefaultValue();
+        verify( popup.view ).addDefaultValueIfNoPresent();
         verify( popup.view ).setDefaultValueVisibility( true );
         assertEquals( null, popup.getEditingCol().getDefaultValue().getStringValue() );
 
@@ -267,7 +267,7 @@ public class ConditionPopupTest {
         verify( popup.view, never() ).addLimitedEntryValue();
         verify( popup.view, never() ).setLimitedEntryVisibility( anyBoolean() );
 
-        verify( popup.view, never() ).addDefaultValue();
+        verify( popup.view, never() ).addDefaultValueIfNoPresent();
         verify( popup.view, never() ).setDefaultValueVisibility( anyBoolean() );
 
         verify( popup.view, never() ).setOperatorLabelText( anyString() );

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupViewTest.java
@@ -6,12 +6,15 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.guided.dtable.shared.model.ConditionCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
 import org.drools.workbench.models.guided.dtable.shared.model.Pattern52;
+import org.drools.workbench.screens.guided.dtable.client.resources.i18n.GuidedDecisionTableConstants;
 import org.drools.workbench.screens.guided.dtable.client.resources.images.GuidedDecisionTableImageResources508;
 import org.drools.workbench.screens.guided.rule.client.editor.CEPWindowOperatorsDropdown;
 import org.gwtbootstrap3.client.ui.InlineRadio;
@@ -29,7 +32,10 @@ import org.uberfire.ext.widgets.common.client.common.ImageButton;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -247,5 +253,14 @@ public class ConditionPopupViewTest {
         verify( binding ).addChangeHandler( changeHandlerCaptor.capture() );
         changeHandlerCaptor.getValue().onChange( changeEvent );
         verify( presenter ).setBinding( "NewBinding" );
+    }
+
+    @Test
+    public void testAddDefaultValueIfNoPresent() throws Exception {
+        verify( view, never() ).addAttribute( anyString(), any( IsWidget.class ) );
+        view.addDefaultValueIfNoPresent();
+        verify( view ).addAttribute( eq( GuidedDecisionTableConstants.INSTANCE.DefaultValue() + ":" ), any( SimplePanel.class ) );
+        view.addDefaultValueIfNoPresent();
+        verify( view ).addAttribute( eq( GuidedDecisionTableConstants.INSTANCE.DefaultValue() + ":" ), any( SimplePanel.class ) );
     }
 }


### PR DESCRIPTION
This PR prevents addition of the widget for **Default Value** multiple times. I decided for the simplest solution as this is fix for regression and @karreiro is doing refactoring in this area.

The other possibility I see is to make the method `ConditionPopupView.addDefaultValueIfNoPresent()` private and initialize the **Default Value** widget as part of ConditionPopUp initialization and no as part of `ConditionPopup.makeDefaultValueWidget()`.