### PR TITLE
Ensure LogoNavBar is top-most

### DIFF
--- a/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/AppNavBar.java
+++ b/drools-wb-webapp/src/main/java/org/drools/workbench/client/navbar/AppNavBar.java
@@ -15,6 +15,9 @@
 
 package org.drools.workbench.client.navbar;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
@@ -22,9 +25,6 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.workbench.Header;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 import static java.lang.Integer.MAX_VALUE;
 
@@ -40,8 +40,9 @@ public class AppNavBar implements Header {
     private WorkbenchMenuBarPresenter menuBarPresenter;
 
     @AfterInitialization
-    public void setup(){
-        DOMUtil.appendWidgetToElement( header, menuBarPresenter.getView().asWidget() );
+    public void setup() {
+        DOMUtil.appendWidgetToElement(header,
+                                      menuBarPresenter.getView().asWidget());
     }
 
     @Override
@@ -51,6 +52,6 @@ public class AppNavBar implements Header {
 
     @Override
     public int getOrder() {
-        return MAX_VALUE;
+        return MAX_VALUE - 1;
     }
 }


### PR DESCRIPTION
This PR ensures the ```LogoNavBar``` is top-most by moving the ```AppNavBar``` down one in order (both had an order of ```Integer.MAX_VALUE``` and hence their runtime order could be indeterminate).