### PR TITLE
[GUVNOR-2880] remove unused field causing issues on Tomcat

### DIFF
--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/model/TestScenarioResult.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-api/src/main/java/org/drools/workbench/screens/testscenario/model/TestScenarioResult.java
@@ -24,23 +24,16 @@ import java.util.Set;
 @Portable
 public class TestScenarioResult {
 
-    private String identifier;
     private Scenario scenario;
     private Set<String> log;
 
     public TestScenarioResult() {
     }
 
-    public TestScenarioResult(String identifier,
-                              Scenario scenario,
+    public TestScenarioResult(Scenario scenario,
                               Set<String> log) {
-        this.identifier = identifier;
         this.scenario = scenario;
         this.log = log;
-    }
-
-    public String getIdentifier() {
-        return identifier;
     }
 
     public Scenario getScenario() {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerService.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/main/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerService.java
@@ -36,7 +36,6 @@ import org.guvnor.structure.server.config.ConfigItem;
 import org.guvnor.structure.server.config.ConfigType;
 import org.guvnor.structure.server.config.ConfigurationService;
 import org.jboss.errai.bus.server.annotations.Service;
-import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -55,12 +54,12 @@ import static org.drools.workbench.screens.testscenario.backend.server.ScenarioU
 public class ScenarioRunnerService
         implements TestService {
 
+    public static final String TEST_SCENARIO_SERVICE_ID = "test-scenario-service";
     protected KieProjectService        projectService;
     private   ScenarioLoader           scenarioLoader;
     private   SessionService           sessionService;
     private   Event<TestResultMessage> defaultTestResultMessageEvent;
     private   ConfigurationService     configurationService;
-    protected User                     identity;
 
     public ScenarioRunnerService() {
     }
@@ -70,14 +69,12 @@ public class ScenarioRunnerService
                                  final Event<TestResultMessage> defaultTestResultMessageEvent,
                                  final SessionService sessionService,
                                  final KieProjectService projectService,
-                                 final ScenarioLoader scenarioLoader,
-                                 final User identity) {
+                                 final ScenarioLoader scenarioLoader) {
         this.configurationService = configurationService;
         this.defaultTestResultMessageEvent = defaultTestResultMessageEvent;
         this.sessionService = sessionService;
         this.projectService = projectService;
         this.scenarioLoader = scenarioLoader;
-        this.identity = identity;
     }
 
     public TestScenarioResult run(final Scenario scenario,
@@ -97,7 +94,7 @@ public class ScenarioRunnerService
 
             run(scenarioRunner, defaultTestResultMessageEvent);
 
-            return new TestScenarioResult(identity.getIdentifier(), scenario, auditLogger.getLog());
+            return new TestScenarioResult(scenario, auditLogger.getLog());
 
         } catch (InitializationError initializationError) {
             throw new GenericPortableException(initializationError.getMessage());
@@ -146,7 +143,7 @@ public class ScenarioRunnerService
 
         testResultMessageEvent.fire(
                 new TestResultMessage(
-                        identity.getIdentifier(),
+                        TEST_SCENARIO_SERVICE_ID,
                         result.getRunCount(),
                         result.getRunTime(),
                         failures));

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerServiceTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-backend/src/test/java/org/drools/workbench/screens/testscenario/backend/server/ScenarioRunnerServiceTest.java
@@ -60,7 +60,6 @@ public class ScenarioRunnerServiceTest {
     public void setUp() throws Exception {
         ConfigurationService configurationService = mock(ConfigurationService.class);
         KieProjectService projectService = mock(KieProjectService.class);
-        User identity = mock(User.class);
 
         defaultTestResultMessageEvent = spy(new TestResultMessageEventMock());
 
@@ -68,11 +67,9 @@ public class ScenarioRunnerServiceTest {
                                             defaultTestResultMessageEvent,
                                             sessionService,
                                             projectService,
-                                            scenarioLoader,
-                                            identity);
+                                            scenarioLoader);
 
         when(sessionService.newDefaultKieSessionWithPseudoClock(any(KieProject.class))).thenReturn(defaultPseudoClockKieSession);
-        when(identity.getIdentifier()).thenReturn("testUser");
 
     }
 
@@ -86,7 +83,7 @@ public class ScenarioRunnerServiceTest {
 
         ArgumentCaptor<TestResultMessage> argumentCaptor = ArgumentCaptor.forClass(TestResultMessage.class);
         verify(defaultTestResultMessageEvent).fire(argumentCaptor.capture());
-        assertEquals("testUser", argumentCaptor.getValue().getIdentifier());
+        assertEquals(ScenarioRunnerService.TEST_SCENARIO_SERVICE_ID, argumentCaptor.getValue().getIdentifier());
     }
 
     @Test
@@ -104,7 +101,7 @@ public class ScenarioRunnerServiceTest {
 
         ArgumentCaptor<TestResultMessage> argumentCaptor = ArgumentCaptor.forClass(TestResultMessage.class);
         verify(defaultTestResultMessageEvent).fire(argumentCaptor.capture());
-        assertEquals("testUser", argumentCaptor.getValue().getIdentifier());
+        assertEquals(ScenarioRunnerService.TEST_SCENARIO_SERVICE_ID, argumentCaptor.getValue().getIdentifier());
     }
 
     private Scenario makeScenario(String name) {

--- a/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenterTest.java
+++ b/drools-wb-screens/drools-wb-test-scenario-editor/drools-wb-test-scenario-editor-client/src/test/java/org/drools/workbench/screens/testscenario/client/ScenarioEditorPresenterTest.java
@@ -210,8 +210,7 @@ public class ScenarioEditorPresenterTest {
             }
 
             @Override public TestScenarioResult runScenario(Path path, Scenario scenario) {
-                TestScenarioResult result = new TestScenarioResult("user",
-                                                                   scenarioRunResult,
+                TestScenarioResult result = new TestScenarioResult(scenarioRunResult,
                                                                    new HashSet<String>());
                 remoteCallback.callback(result);
                 return null;


### PR DESCRIPTION
The biggest issue with the User field was that it was @RequestScoped.
The ScenarioRunnerService is being used as part of AsyncJobs (e.g.
when the project/maven/test REST endpoint is triggered). On Tomcat
this does not work, becuase the request thread is different from the
processing thread and thus the request scoped variables are not
available. For some reason this works on WildFly 10 / EAP7
(most likely because we use the async EJBs there, instead of the
thred pool).

@Rikkola could you please review?