### PR TITLE
[DROOLS-1452] remove no longer needed exclusion

### DIFF
--- a/drools-wb-webapp/pom.xml
+++ b/drools-wb-webapp/pom.xml
@@ -973,17 +973,6 @@
       <artifactId>org.eclipse.sisu.inject</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.sonatype.sisu</groupId>
-      <artifactId>sisu-guice</artifactId>
-      <classifier>no_aop</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.sonatype.sisu</groupId>
-          <artifactId>sisu-guava</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
sisu-guice was replaced directly by the standard guice,
which no longer depends on sisu-guava

Depends on https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/401