### PR TITLE
Fix bouncycastle exclusions after itext upgrade

### DIFF
--- a/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-export/pom.xml
+++ b/drools-wb-jcr2vfs-migration/drools-wb-jcr2vfs-export/pom.xml
@@ -108,6 +108,10 @@
           <groupId>bouncycastle</groupId>
           <artifactId>bcprov-jdk14</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bctsp-jdk14</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
Depends on https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/405