### PR TITLE
refactor stubbed tests to not fail with offline jacoco instrumentation

### DIFF
--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionInsertFactPopup.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionInsertFactPopup.java
@@ -278,9 +278,9 @@ public class ActionInsertFactPopup extends FormStylePopup {
     }
 
     private ImageButton createEditFieldButton() {
-        Image edit = GuidedDecisionTableImageResources508.INSTANCE.Edit();
+        Image edit = getEditImage();
         edit.setAltText( GuidedDecisionTableConstants.INSTANCE.EditTheFieldThatThisColumnOperatesOn() );
-        Image editDisabled = GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+        Image editDisabled = getEditDisabledImage();
         editDisabled.setAltText( GuidedDecisionTableConstants.INSTANCE.EditTheFieldThatThisColumnOperatesOn() );
         return new ImageButton( edit,
                                 editDisabled,
@@ -293,9 +293,9 @@ public class ActionInsertFactPopup extends FormStylePopup {
     }
 
     private ImageButton createChangePatternButton() {
-        Image edit = GuidedDecisionTableImageResources508.INSTANCE.Edit();
+        Image edit = getEditImage();
         edit.setAltText( GuidedDecisionTableConstants.INSTANCE.ChooseAPatternThatThisColumnAddsDataTo() );
-        Image editDisabled = GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+        Image editDisabled = getEditDisabledImage();
         editDisabled.setAltText( GuidedDecisionTableConstants.INSTANCE.ChooseAPatternThatThisColumnAddsDataTo() );
 
         return new ImageButton( edit,
@@ -306,6 +306,14 @@ public class ActionInsertFactPopup extends FormStylePopup {
                                         showChangePattern( w );
                                     }
                                 } );
+    }
+
+    protected Image getEditDisabledImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+    }
+
+    protected Image getEditImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.Edit();
     }
 
     private boolean allowEmptyValues() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionSetFieldPopup.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionSetFieldPopup.java
@@ -285,15 +285,23 @@ public class ActionSetFieldPopup extends FormStylePopup {
     }
 
     private Image createDisabledEditButton() {
-        Image disabledChangePattern = GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+        Image disabledChangePattern = getEditDisabledImage();
         disabledChangePattern.setAltText( GuidedDecisionTableConstants.INSTANCE.ChooseABoundFactThatThisColumnPertainsTo() );
         return disabledChangePattern;
     }
 
+    protected Image getEditDisabledImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+    }
+
     private Image createEnabledEditButton() {
-        Image enabledChangePattern = GuidedDecisionTableImageResources508.INSTANCE.Edit();
+        Image enabledChangePattern = getEditImage();
         enabledChangePattern.setAltText( GuidedDecisionTableConstants.INSTANCE.ChooseABoundFactThatThisColumnPertainsTo() );
         return enabledChangePattern;
+    }
+
+    protected Image getEditImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.Edit();
     }
 
     private boolean allowEmptyValues() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopup.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopup.java
@@ -129,8 +129,12 @@ public class ConditionPopup {
                                                        isReadOnly,
                                                        allowEmptyValues());
 
-        view = new ConditionPopupView(this);
+        view = getWidgets();
         view.initializeView();
+    }
+
+    protected ConditionPopupView getWidgets() {
+        return new ConditionPopupView(this);
     }
 
     public void show() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupView.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/main/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupView.java
@@ -26,11 +26,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.SimplePanel;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.*;
 import org.drools.workbench.models.datamodel.rule.BaseSingleFieldConstraint;
 import org.drools.workbench.models.datamodel.rule.HasCEPWindow;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52.TableFormat;
@@ -102,22 +98,30 @@ public class ConditionPopupView extends FormStylePopup {
 
         this.presenter = presenter;
 
-        changePattern = new ImageButton( GuidedDecisionTableImageResources508.INSTANCE.Edit(),
-                GuidedDecisionTableImageResources508.INSTANCE.EditDisabled(),
+        changePattern = new ImageButton(getEditImage(),
+                getDisabledImage(),
                 GuidedDecisionTableConstants.INSTANCE.ChooseAnExistingPatternThatThisColumnAddsTo()
         );
 
-        editField = new ImageButton( GuidedDecisionTableImageResources508.INSTANCE.Edit(),
-                GuidedDecisionTableImageResources508.INSTANCE.EditDisabled(),
+        editField = new ImageButton(getEditImage(),
+                getDisabledImage(),
                 GuidedDecisionTableConstants.INSTANCE.EditTheFieldThatThisColumnOperatesOn() );
 
-        editOp = new ImageButton( GuidedDecisionTableImageResources508.INSTANCE.Edit(),
-                GuidedDecisionTableImageResources508.INSTANCE.EditDisabled(),
+        editOp = new ImageButton(getEditImage(),
+                getDisabledImage(),
                 GuidedDecisionTableConstants.INSTANCE.EditTheOperatorThatIsUsedToCompareDataWithThisField() );
 
         entryPointName = new TextBox();
         header = new TextBox();
         valueListWidget = new TextBox();
+    }
+
+    protected Image getDisabledImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.EditDisabled();
+    }
+
+    protected Image getEditImage() {
+        return GuidedDecisionTableImageResources508.INSTANCE.Edit();
     }
 
     public void initializeView() {

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionInsertFactPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionInsertFactPopupTest.java
@@ -18,12 +18,12 @@ package org.drools.workbench.screens.guided.dtable.client.widget;
 
 import java.util.HashMap;
 
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.oracle.DataType;
 import org.drools.workbench.models.guided.dtable.shared.model.ActionInsertFactCol52;
 import org.drools.workbench.models.guided.dtable.shared.model.GuidedDecisionTable52;
-import org.drools.workbench.screens.guided.dtable.client.resources.images.GuidedDecisionTableImageResources508;
 import org.drools.workbench.screens.guided.dtable.client.widget.table.GuidedDecisionTableView;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.junit.BeforeClass;
@@ -36,7 +36,7 @@ import org.mockito.Mock;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
-@WithClassesToStub({ Text.class, GuidedDecisionTableImageResources508.class })
+@WithClassesToStub({ Text.class })
 public class ActionInsertFactPopupTest {
 
     @Mock
@@ -68,7 +68,17 @@ public class ActionInsertFactPopupTest {
                                                      refreshGrid,
                                                      column,
                                                      isNew,
-                                                     isReadOnly ) );
+                                                     isReadOnly) {
+            @Override
+            protected Image getEditImage() {
+                return mock(Image.class);
+            }
+
+            @Override
+            protected Image getEditDisabledImage() {
+                return mock (Image.class);
+            }
+        } );
     }
 
     @Test

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionSetFieldPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ActionSetFieldPopupTest.java
@@ -18,6 +18,7 @@ package org.drools.workbench.screens.guided.dtable.client.widget;
 
 import java.util.HashMap;
 
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.oracle.DataType;
@@ -39,7 +40,7 @@ import org.uberfire.ext.widgets.common.client.common.ImageButton;
 import static org.mockito.Mockito.*;
 
 @RunWith(GwtMockitoTestRunner.class)
-@WithClassesToStub({ Text.class, GuidedDecisionTableImageResources508.class })
+@WithClassesToStub({ Text.class })
 public class ActionSetFieldPopupTest {
 
     @Mock
@@ -71,7 +72,17 @@ public class ActionSetFieldPopupTest {
                                                    refreshGrid,
                                                    column,
                                                    isNew,
-                                                   isReadOnly ) );
+                                                   isReadOnly ) {
+            @Override
+            protected Image getEditImage() { return mock(Image.class); }
+
+            @Override
+            protected Image getEditDisabledImage() {
+                return mock (Image.class);
+            }
+
+        });
+
         this.popup.editField = mock( ImageButton.class );
     }
 

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import org.drools.workbench.models.datamodel.oracle.DataType;
@@ -105,7 +106,17 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+
+            @Override
+            protected Image getEditImage(){
+                return mock(Image.class);
+            }
+            @Override
+            protected Image getDisabledImage(){
+                return mock(Image.class);
+            }
+        });
     }
 
     private void setUpPopup(final GuidedDecisionTable52 model,
@@ -120,7 +131,12 @@ public class ConditionPopupTest {
                                             pattern,
                                             column,
                                             isNew,
-                                            isReadOnly));
+                                            isReadOnly){
+            @Override
+            protected ConditionPopupView getWidgets(){
+                return mock(ConditionPopupView.class);
+            }
+        });
     }
 
     @Test
@@ -320,7 +336,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view).warnAboutMissingColumnHeaderDescription();
@@ -335,7 +356,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view).warnAboutMissingFactField();
@@ -350,7 +376,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view).warnAboutMissingOperator();
@@ -384,7 +415,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view,
@@ -400,7 +436,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view,
@@ -416,7 +457,12 @@ public class ConditionPopupTest {
                    false,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view,
@@ -440,7 +486,12 @@ public class ConditionPopupTest {
                    true,
                    false);
 
-        popup.view = spy(new ConditionPopupView(popup));
+        popup.view = spy(new ConditionPopupView(popup){
+            @Override
+            protected Image getEditImage(){ return mock(Image.class); }
+            @Override
+            protected Image getDisabledImage(){ return mock(Image.class); }
+        });
 
         popup.applyChanges();
         verify(popup.view).warnAboutAlreadyUsedColumnHeaderName();

--- a/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupViewTest.java
+++ b/drools-wb-screens/drools-wb-guided-dtable-editor/drools-wb-guided-dtable-editor-client/src/test/java/org/drools/workbench/screens/guided/dtable/client/widget/ConditionPopupViewTest.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -36,11 +37,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 @WithClassesToStub( {Modal.class,
                      GuidedDecisionTableImageResources508.class,
@@ -121,7 +119,16 @@ public class ConditionPopupViewTest {
         when( presenter.getEditingPattern() ).thenReturn( pattern52 );
         when( presenter.getConstraintValueType() ).thenReturn( BaseSingleFieldConstraint.TYPE_LITERAL );
         when( presenter.getTableFormat() ).thenReturn( GuidedDecisionTable52.TableFormat.EXTENDED_ENTRY );
-        view = spy( new ConditionPopupView( presenter ) );
+        view = spy( new ConditionPopupView( presenter ) {
+            @Override
+            protected Image getEditImage(){
+                return mock(Image.class);
+            }
+            @Override
+            protected Image getDisabledImage(){
+                return mock(Image.class);
+            }
+        });
     }
 
 

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopup.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/main/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopup.java
@@ -35,8 +35,13 @@ public abstract class AttributeSelectorPopup extends FormStylePopup {
     protected ListBox list;
 
     public AttributeSelectorPopup() {
-        super( GuidedRuleEditorImages508.INSTANCE.Configure(),
+        this( GuidedRuleEditorImages508.INSTANCE.Configure(),
                GuidedRuleEditorResources.CONSTANTS.AddAnOptionToTheRule() );
+    }
+
+    public AttributeSelectorPopup( final Image icon,
+                                   final String title ) {
+        super(icon, title);
     }
 
     protected final void initialize() {
@@ -104,7 +109,7 @@ public abstract class AttributeSelectorPopup extends FormStylePopup {
 
     protected abstract void handleAttributeAddition( final String attributeName );
 
-    private Image getAddButton() {
+    protected Image getAddButton() {
         final Image addbutton = GuidedRuleEditorImages508.INSTANCE.NewItem();
         addbutton.setAltText( GuidedRuleEditorResources.CONSTANTS.AddMetadataToTheRule() );
         addbutton.setTitle( GuidedRuleEditorResources.CONSTANTS.AddMetadataToTheRule() );

--- a/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopupTest.java
+++ b/drools-wb-screens/drools-wb-guided-rule-editor/drools-wb-guided-rule-editor-client/src/test/java/org/drools/workbench/screens/guided/rule/client/editor/AttributeSelectorPopupTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.Image;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -43,7 +44,7 @@ import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-@WithClassesToStub({GuidedRuleEditorImages508.class, Heading.class})
+@WithClassesToStub({Heading.class})
 @RunWith(GwtMockitoTestRunner.class)
 public class AttributeSelectorPopupTest {
 
@@ -119,6 +120,10 @@ public class AttributeSelectorPopupTest {
 
     private static class MockAttributeSelectorPopup extends AttributeSelectorPopup {
 
+        public MockAttributeSelectorPopup(){
+            super(mock(Image.class),"titleMock");
+        }
+
         @Override
         protected String[] getAttributes() {
             return attributes;
@@ -147,6 +152,11 @@ public class AttributeSelectorPopupTest {
         @Override
         protected void handleMetadataAddition(String metadataName) {
             // mock, do nothing
+        }
+
+        @Override
+        protected Image getAddButton(){
+            return mock(Image.class);
         }
     }
 }


### PR DESCRIPTION
ConditionPopupTest, ConditionPopupViewTest, ActionInsertFactPopupTest, ActionSetFieldPopupTest and AtributeSelectorPopupTest (and corresponding classes) have been refactored to not fail with the new jacoco setup in https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/381.